### PR TITLE
feat:update news view in app and fix wwise ui bug

### DIFF
--- a/lib/ui/home/dialogs/home_news_content_dialog_ui.dart
+++ b/lib/ui/home/dialogs/home_news_content_dialog_ui.dart
@@ -1,0 +1,287 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/material.dart' show Material;
+import 'package:html/dom.dart' as html_dom;
+import 'package:html/parser.dart' as html;
+import 'package:starcitizen_doctor/widgets/widgets.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+class HomeNewsContentDialogUI extends StatelessWidget {
+  static const _gap1em = "\u0000NEWS_GAP_1EM\u0000";
+  static const _gap2em = "\u0000NEWS_GAP_2EM\u0000";
+
+  final String title;
+  final String author;
+  final String pubDate;
+  final String tag;
+  final String link;
+  final String description;
+  final List<String> detailedDescription;
+
+  const HomeNewsContentDialogUI({
+    super.key,
+    required this.title,
+    required this.author,
+    required this.pubDate,
+    required this.tag,
+    required this.link,
+    required this.description,
+    required this.detailedDescription,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final content = _buildMarkdownContent();
+    final size = MediaQuery.of(context).size;
+
+    return Material(
+      child: ContentDialog(
+        constraints: BoxConstraints(
+          maxWidth: size.width * .72,
+          maxHeight: size.height * .82,
+        ),
+        title: Text(title),
+        content: ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: size.height * .62),
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.only(left: 12, right: 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Wrap(
+                    spacing: 10,
+                    runSpacing: 6,
+                    children: [
+                      if (author.trim().isNotEmpty) _MetaText(author.trim()),
+                      if (tag.trim().isNotEmpty) _MetaText(tag.trim()),
+                      if (pubDate.trim().isNotEmpty) _MetaText(pubDate.trim()),
+                    ],
+                  ),
+                  if (content.trim().isNotEmpty) ...[
+                    const SizedBox(height: 12),
+                    ..._buildContentWidgets(content),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+        actions: [
+          if (link.trim().isNotEmpty)
+            Button(
+              onPressed: () => launchUrlString(link),
+              child: const Text("打开原文"),
+            ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context),
+            child: Padding(
+              padding: const EdgeInsets.only(
+                left: 8,
+                right: 8,
+                top: 2,
+                bottom: 2,
+              ),
+              child: Text(S.current.action_close),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _buildMarkdownContent() {
+    final source = detailedDescription
+        .where((e) => e.trim().isNotEmpty)
+        .join("\n\n");
+    final body = source.trim().isNotEmpty ? source : description;
+    final markdown = _htmlToMarkdown(body).trim();
+    if (markdown.isNotEmpty) return markdown;
+    return description.trim();
+  }
+
+  String _htmlToMarkdown(String input) {
+    if (input.trim().isEmpty) return "";
+    final fragment = html.parseFragment(_cleanupNewsHtml(input));
+    final buffer = StringBuffer();
+    for (final node in fragment.nodes) {
+      _writeNode(buffer, node);
+    }
+    return buffer
+        .toString()
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .replaceAll(RegExp(r'[ \t]+\n'), '\n')
+        .trim();
+  }
+
+  String _cleanupNewsHtml(String input) {
+    var htmlText = input;
+    htmlText = htmlText.replaceAll(
+      RegExp(
+        r"""<div\b[^>]*class=["'][^"']*\bvideo_src_wrapper\b[^"']*["'][^>]*>.*?</div>""",
+        caseSensitive: false,
+        dotAll: true,
+      ),
+      '<p>贴吧视频需在原帖观看</p>',
+    );
+    htmlText = htmlText.replaceAll(
+      RegExp(
+        r'<br\s*/?>\s*作者：.*?<br\s*/?>\s*楼层：.*?楼\s*<br\s*/?>',
+        caseSensitive: false,
+        dotAll: true,
+      ),
+      '',
+    );
+    for (final noise in ['本楼含有高级字体', '来自iPhone客户端', '作者：灬灬G灬灬', '楼层：1楼']) {
+      htmlText = htmlText.replaceAll(noise, '');
+    }
+    htmlText = htmlText.replaceAll(
+      RegExp(r'(<br\s*/?>\s*){2,}', caseSensitive: false),
+      '<br>',
+    );
+    htmlText = htmlText.replaceAll(
+      RegExp(r'<br\s*/?>', caseSensitive: false),
+      '<div style="margin-bottom: 1em;"></div>',
+    );
+    htmlText = htmlText.replaceAll(
+      RegExp(
+        r"""<div\s+style=["']margin-bottom:\s*1em;?["']\s*>\s*</div>\s*\.\s*<div\s+style=["']margin-bottom:\s*1em;?["']\s*>\s*</div>""",
+        caseSensitive: false,
+      ),
+      '<div style="margin-bottom: 2em;"></div><div style="margin-bottom: 2em;"></div>',
+    );
+    return htmlText;
+  }
+
+  List<Widget> _buildContentWidgets(String content) {
+    final widgets = <Widget>[];
+    final gapPattern = RegExp(
+      '(${RegExp.escape(_gap1em)}|${RegExp.escape(_gap2em)})',
+    );
+    var cursor = 0;
+    for (final match in gapPattern.allMatches(content)) {
+      final text = content.substring(cursor, match.start);
+      _addContentPart(widgets, text);
+      _addContentPart(widgets, match.group(0) ?? "");
+      cursor = match.end;
+    }
+    _addContentPart(widgets, content.substring(cursor));
+    return widgets;
+  }
+
+  void _addContentPart(List<Widget> widgets, String part) {
+    if (part.isEmpty) return;
+    if (part == _gap1em) {
+      widgets.add(const SizedBox(height: 14));
+    } else if (part == _gap2em) {
+      widgets.add(const SizedBox(height: 28));
+    } else if (part.trim().isNotEmpty) {
+      widgets.addAll(makeMarkdownView(part.trim()));
+    }
+  }
+
+  void _writeNode(StringBuffer buffer, html_dom.Node node) {
+    if (node is html_dom.Text) {
+      buffer.write(node.text);
+      return;
+    }
+    if (node is! html_dom.Element) return;
+
+    switch (node.localName) {
+      case "br":
+        buffer.write(_gap1em);
+        return;
+      case "img":
+        final src = node.attributes["src"]?.trim() ?? "";
+        if (src.isNotEmpty) {
+          buffer.write("\n\n![]($src)\n\n");
+        }
+        return;
+      case "iframe":
+        final src = node.attributes["src"]?.trim() ?? "";
+        if (src.isNotEmpty) {
+          buffer.write("\n\n[播放视频]($src)\n\n");
+        }
+        return;
+      case "h1":
+        _writeBlockText(buffer, node, "# ");
+        return;
+      case "h2":
+        _writeBlockText(buffer, node, "## ");
+        return;
+      case "h3":
+        _writeBlockText(buffer, node, "### ");
+        return;
+      case "a":
+        final href = node.attributes["href"]?.trim() ?? "";
+        final text = node.text.trim();
+        if (href.isNotEmpty && text.isNotEmpty) {
+          buffer.write("[$text]($href)");
+        } else {
+          _writeChildren(buffer, node);
+        }
+        return;
+      case "li":
+        buffer.write("\n- ");
+        _writeChildren(buffer, node);
+        return;
+      case "p":
+      case "div":
+        if (_writeMarginDiv(buffer, node)) return;
+        buffer.write("\n");
+        _writeChildren(buffer, node);
+        buffer.write("\n");
+        return;
+      case "section":
+      case "article":
+        buffer.write("\n");
+        _writeChildren(buffer, node);
+        buffer.write("\n");
+        return;
+      default:
+        _writeChildren(buffer, node);
+    }
+  }
+
+  void _writeBlockText(
+    StringBuffer buffer,
+    html_dom.Element node,
+    String prefix,
+  ) {
+    final text = node.text.trim();
+    if (text.isEmpty) return;
+    buffer.write("\n\n$prefix$text\n\n");
+  }
+
+  void _writeChildren(StringBuffer buffer, html_dom.Element node) {
+    for (final child in node.nodes) {
+      _writeNode(buffer, child);
+    }
+  }
+
+  bool _writeMarginDiv(StringBuffer buffer, html_dom.Element node) {
+    if (node.localName != "div" || node.nodes.isNotEmpty) return false;
+    final style = node.attributes["style"]?.toLowerCase() ?? "";
+    if (!style.contains("margin-bottom")) return false;
+    if (RegExp(r'margin-bottom\s*:\s*2em').hasMatch(style)) {
+      buffer.write(_gap2em);
+    } else {
+      buffer.write(_gap1em);
+    }
+    return true;
+  }
+}
+
+class _MetaText extends StatelessWidget {
+  final String text;
+
+  const _MetaText(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: TextStyle(fontSize: 12, color: Colors.white.withValues(alpha: .6)),
+    );
+  }
+}

--- a/lib/ui/home/home_ui.dart
+++ b/lib/ui/home/home_ui.dart
@@ -17,6 +17,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 
 import 'dialogs/home_countdown_dialog_ui.dart';
 import 'dialogs/home_md_content_dialog_ui.dart';
+import 'dialogs/home_news_content_dialog_ui.dart';
 import 'home_ui_model.dart';
 import 'input_method/input_method_dialog_ui.dart';
 import 'localization/localization_dialog_ui.dart';
@@ -55,7 +56,9 @@ class HomeUI extends HookConsumerWidget {
                             child: Text(S.current.doctor_action_view_details),
                             onPressed: () => _showPlacard(context, homeState),
                           ),
-                    onClose: homeState.appPlacardData?.alwaysShow == true ? null : () => model.closePlacard(),
+                    onClose: homeState.appPlacardData?.alwaysShow == true
+                        ? null
+                        : () => model.closePlacard(),
                   ),
                   const SizedBox(height: 6),
                 ],
@@ -74,7 +77,9 @@ class HomeUI extends HookConsumerWidget {
                   const ProgressRing(),
                   const SizedBox(height: 12),
                   Text(
-                    homeState.isFixingString.isNotEmpty ? homeState.isFixingString : S.current.doctor_info_processing,
+                    homeState.isFixingString.isNotEmpty
+                        ? homeState.isFixingString
+                        : S.current.doctor_info_processing,
                   ),
                 ],
               ),
@@ -84,7 +89,12 @@ class HomeUI extends HookConsumerWidget {
     );
   }
 
-  List<Widget> makeIndex(BuildContext context, HomeUIModel model, HomeUIModelState homeState, WidgetRef ref) {
+  List<Widget> makeIndex(
+    BuildContext context,
+    HomeUIModel model,
+    HomeUIModelState homeState,
+    WidgetRef ref,
+  ) {
     double width = 280;
     return [
       Stack(
@@ -98,7 +108,11 @@ class HomeUI extends HookConsumerWidget {
                   children: [
                     Padding(
                       padding: const EdgeInsets.only(bottom: 30),
-                      child: Image.asset("assets/sc_logo.png", fit: BoxFit.fitHeight, height: 260),
+                      child: Image.asset(
+                        "assets/sc_logo.png",
+                        fit: BoxFit.fitHeight,
+                        height: 260,
+                      ),
                     ),
                     makeGameStatusCard(context, model, 340, homeState),
                   ],
@@ -106,8 +120,16 @@ class HomeUI extends HookConsumerWidget {
               ),
             ),
           ),
-          Positioned(top: 0, left: 24, child: makeLeftColumn(context, model, width, homeState)),
-          Positioned(right: 24, top: 0, child: makeNewsCard(context, model, homeState)),
+          Positioned(
+            top: 0,
+            left: 24,
+            child: makeLeftColumn(context, model, width, homeState),
+          ),
+          Positioned(
+            right: 24,
+            top: 0,
+            child: makeNewsCard(context, model, homeState),
+          ),
         ],
       ),
       const SizedBox(height: 24),
@@ -123,7 +145,10 @@ class HomeUI extends HookConsumerWidget {
                 await context.push("/guide");
                 await model.reScanPath();
               },
-              child: const Padding(padding: EdgeInsets.all(6), child: Icon(FluentIcons.settings)),
+              child: const Padding(
+                padding: EdgeInsets.all(6),
+                child: Icon(FluentIcons.settings),
+              ),
             ),
             const SizedBox(width: 6),
             Expanded(
@@ -131,7 +156,10 @@ class HomeUI extends HookConsumerWidget {
                 value: homeState.scInstalledPath,
                 isExpanded: true,
                 items: [
-                  ComboBoxItem(value: "not_install", child: Text(S.current.home_not_installed_or_failed)),
+                  ComboBoxItem(
+                    value: "not_install",
+                    child: Text(S.current.home_not_installed_or_failed),
+                  ),
                   for (final path in homeState.scInstallPaths)
                     ComboBoxItem(
                       value: path,
@@ -144,29 +172,50 @@ class HomeUI extends HookConsumerWidget {
             if (S.current.app_language_code == NoL10n.langCodeZhCn) ...[
               const SizedBox(width: 12),
               Button(
-                onPressed: homeState.webLocalizationVersionsData == null ? null : () => model.launchRSI(context),
+                onPressed: homeState.webLocalizationVersionsData == null
+                    ? null
+                    : () => model.launchRSI(context),
                 style: homeState.isCurGameRunning
                     ? null
-                    : ButtonStyle(backgroundColor: WidgetStateProperty.resolveWith(_getRunButtonColor)),
+                    : ButtonStyle(
+                        backgroundColor: WidgetStateProperty.resolveWith(
+                          _getRunButtonColor,
+                        ),
+                      ),
                 child: Padding(
                   padding: const EdgeInsets.all(6),
                   child: Icon(
-                    homeState.isCurGameRunning ? FluentIcons.stop_solid : FluentIcons.play_solid,
-                    color: homeState.isCurGameRunning ? Colors.red.withValues(alpha: .8) : Colors.white,
+                    homeState.isCurGameRunning
+                        ? FluentIcons.stop_solid
+                        : FluentIcons.play_solid,
+                    color: homeState.isCurGameRunning
+                        ? Colors.red.withValues(alpha: .8)
+                        : Colors.white,
                   ),
                 ),
               ),
             ],
             const SizedBox(width: 12),
             Button(
-              onPressed: () => _checkAndGoInputMethod(context, homeState, model, ref),
-              style: ButtonStyle(backgroundColor: WidgetStateProperty.resolveWith((_) => Colors.blue)),
-              child: Padding(padding: const EdgeInsets.all(6), child: Icon(FluentIcons.keyboard_classic)),
+              onPressed: () =>
+                  _checkAndGoInputMethod(context, homeState, model, ref),
+              style: ButtonStyle(
+                backgroundColor: WidgetStateProperty.resolveWith(
+                  (_) => Colors.blue,
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(6),
+                child: Icon(FluentIcons.keyboard_classic),
+              ),
             ),
             const SizedBox(width: 12),
             Button(
               onPressed: model.reScanPath,
-              child: const Padding(padding: EdgeInsets.all(6), child: Icon(FluentIcons.refresh)),
+              child: const Padding(
+                padding: EdgeInsets.all(6),
+                child: Icon(FluentIcons.refresh),
+              ),
             ),
           ],
         ),
@@ -177,7 +226,12 @@ class HomeUI extends HookConsumerWidget {
     ];
   }
 
-  Widget makeLeftColumn(BuildContext context, HomeUIModel model, double width, HomeUIModelState homeState) {
+  Widget makeLeftColumn(
+    BuildContext context,
+    HomeUIModel model,
+    double width,
+    HomeUIModelState homeState,
+  ) {
     return Stack(
       children: [
         Column(
@@ -195,11 +249,21 @@ class HomeUI extends HookConsumerWidget {
                     makeWebViewButton(
                       context,
                       model,
-                      icon: SvgPicture.asset("assets/rsi.svg", colorFilter: makeSvgColor(Colors.white), height: 18),
-                      name: S.current.home_action_star_citizen_website_localization,
-                      webTitle: S.current.home_action_star_citizen_website_localization,
+                      icon: SvgPicture.asset(
+                        "assets/rsi.svg",
+                        colorFilter: makeSvgColor(Colors.white),
+                        height: 18,
+                      ),
+                      name: S
+                          .current
+                          .home_action_star_citizen_website_localization,
+                      webTitle: S
+                          .current
+                          .home_action_star_citizen_website_localization,
                       webURL: "https://robertsspaceindustries.com",
-                      info: S.current.home_action_info_roberts_space_industries_origin,
+                      info: S
+                          .current
+                          .home_action_info_roberts_space_industries_origin,
                       useLocalization: true,
                       width: width,
                       touchKey: "webLocalization_rsi",
@@ -208,11 +272,18 @@ class HomeUI extends HookConsumerWidget {
                     makeWebViewButton(
                       context,
                       model,
-                      icon: Row(children: [SvgPicture.asset("assets/uex.svg", height: 18), const SizedBox(width: 12)]),
+                      icon: Row(
+                        children: [
+                          SvgPicture.asset("assets/uex.svg", height: 18),
+                          const SizedBox(width: 12),
+                        ],
+                      ),
                       name: S.current.home_action_uex_localization,
                       webTitle: S.current.home_action_uex_localization,
                       webURL: "https://uexcorp.space/?set_lang=zh_CN",
-                      info: S.current.home_action_info_mining_refining_trade_calculator,
+                      info: S
+                          .current
+                          .home_action_info_mining_refining_trade_calculator,
                       useLocalization: true,
                       width: width,
                       touchKey: "webLocalization_uex",
@@ -221,11 +292,19 @@ class HomeUI extends HookConsumerWidget {
                     makeWebViewButton(
                       context,
                       model,
-                      icon: Row(children: [Image.asset("assets/dps.png", height: 20), const SizedBox(width: 12)]),
+                      icon: Row(
+                        children: [
+                          Image.asset("assets/dps.png", height: 20),
+                          const SizedBox(width: 12),
+                        ],
+                      ),
                       name: S.current.home_action_dps_calculator_localization,
-                      webTitle: S.current.home_action_dps_calculator_localization,
+                      webTitle:
+                          S.current.home_action_dps_calculator_localization,
                       webURL: "https://www.erkul.games/live/calculator",
-                      info: S.current.home_action_info_ship_upgrade_damage_value_query,
+                      info: S
+                          .current
+                          .home_action_info_ship_upgrade_damage_value_query,
                       useLocalization: true,
                       width: width,
                       touchKey: "webLocalization_dps",
@@ -236,7 +315,10 @@ class HomeUI extends HookConsumerWidget {
                     Row(
                       children: [
                         Button(
-                          child: const FaIcon(FontAwesomeIcons.chrome, size: 18),
+                          child: const FaIcon(
+                            FontAwesomeIcons.chrome,
+                            size: 18,
+                          ),
                           onPressed: () {
                             launchUrlString(
                               "https://chrome.google.com/webstore/detail/gocnjckojmledijgmadmacoikibcggja?authuser=0&hl=zh-CN",
@@ -254,7 +336,10 @@ class HomeUI extends HookConsumerWidget {
                         ),
                         const SizedBox(width: 12),
                         Button(
-                          child: const FaIcon(FontAwesomeIcons.firefoxBrowser, size: 18),
+                          child: const FaIcon(
+                            FontAwesomeIcons.firefoxBrowser,
+                            size: 18,
+                          ),
                           onPressed: () {
                             launchUrlString(
                               "https://addons.mozilla.org/zh-CN/firefox/"
@@ -264,9 +349,14 @@ class HomeUI extends HookConsumerWidget {
                         ),
                         const SizedBox(width: 12),
                         Button(
-                          child: const FaIcon(FontAwesomeIcons.github, size: 18),
+                          child: const FaIcon(
+                            FontAwesomeIcons.github,
+                            size: 18,
+                          ),
                           onPressed: () {
-                            launchUrlString("https://github.com/StarCitizenToolBox/StarCitizenBoxBrowserEx");
+                            launchUrlString(
+                              "https://github.com/StarCitizenToolBox/StarCitizenBoxBrowserEx",
+                            );
                           },
                         ),
                       ],
@@ -293,13 +383,20 @@ class HomeUI extends HookConsumerWidget {
     );
   }
 
-  Widget makeNewsCard(BuildContext context, HomeUIModel model, HomeUIModelState homeState) {
+  Widget makeNewsCard(
+    BuildContext context,
+    HomeUIModel model,
+    HomeUIModelState homeState,
+  ) {
     return ScrollConfiguration(
       behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
       child: Container(
         width: 316,
         height: 386,
-        decoration: BoxDecoration(color: Colors.white.withValues(alpha: .1), borderRadius: BorderRadius.circular(12)),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: .1),
+          borderRadius: BorderRadius.circular(12),
+        ),
         child: SingleChildScrollView(
           child: Column(
             children: [
@@ -308,16 +405,34 @@ class HomeUI extends HookConsumerWidget {
                 width: 316,
                 child: homeState.citizenNewsData == null
                     ? Container(
-                        decoration: BoxDecoration(color: Colors.white.withValues(alpha: .1)),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withValues(alpha: .1),
+                        ),
                         child: makeLoading(context),
                       )
                     : HoverSwiper(
-                        itemCount: getMinNumber([homeState.citizenNewsData?.videos.length ?? 0, 6]),
+                        itemCount: getMinNumber([
+                          homeState.citizenNewsData?.videos.length ?? 0,
+                          6,
+                        ]),
                         itemBuilder: (context, index) {
                           final item = homeState.citizenNewsData?.videos[index];
                           return GestureDetector(
                             onTap: () {
-                              launchUrlString(item?.link ?? "");
+                              if (item == null) return;
+                              _showNewsContentDialog(
+                                context,
+                                title: item.title.replaceAll(
+                                  NoL10n.aniCatTitle,
+                                  "",
+                                ),
+                                author: item.author,
+                                pubDate: item.pubDate,
+                                tag: item.tag,
+                                link: item.link,
+                                description: item.description,
+                                detailedDescription: item.detailedDescription,
+                              );
                             },
                             child: Column(
                               children: [
@@ -330,8 +445,12 @@ class HomeUI extends HookConsumerWidget {
                                   height: 30,
                                   child: Container(
                                     width: double.infinity,
-                                    decoration: BoxDecoration(color: Colors.black),
-                                    padding: EdgeInsets.symmetric(horizontal: 6),
+                                    decoration: BoxDecoration(
+                                      color: Colors.black,
+                                    ),
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: 6,
+                                    ),
                                     child: Center(
                                       child: Row(
                                         children: [
@@ -354,7 +473,10 @@ class HomeUI extends HookConsumerWidget {
                         },
                         paginationActiveSize: 8.0,
                         controlSize: 24,
-                        controlPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+                        controlPadding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 0,
+                        ),
                         autoplayDelay: 5000,
                       ),
               ),
@@ -372,10 +494,24 @@ class HomeUI extends HookConsumerWidget {
                       borderRadius: BorderRadius.circular(12),
                       child: GestureDetector(
                         onTap: () {
-                          launchUrlString(item.link);
+                          _showNewsContentDialog(
+                            context,
+                            title: model.handleTitle(item.title),
+                            author: item.author,
+                            pubDate: item.pubDate,
+                            tag: item.tag,
+                            link: item.link,
+                            description: item.description,
+                            detailedDescription: item.detailedDescription,
+                          );
                         },
                         child: Padding(
-                          padding: const EdgeInsets.only(left: 12, right: 12, top: 4, bottom: 4),
+                          padding: const EdgeInsets.only(
+                            left: 12,
+                            right: 12,
+                            top: 4,
+                            bottom: 4,
+                          ),
                           child: Row(
                             children: [
                               getRssIcon(item.link),
@@ -390,7 +526,11 @@ class HomeUI extends HookConsumerWidget {
                                 ),
                               ),
                               const SizedBox(width: 12),
-                              Icon(FluentIcons.chevron_right, size: 12, color: Colors.white.withValues(alpha: .4)),
+                              Icon(
+                                FluentIcons.chevron_right,
+                                size: 12,
+                                color: Colors.white.withValues(alpha: .4),
+                              ),
                             ],
                           ),
                         ),
@@ -407,19 +547,52 @@ class HomeUI extends HookConsumerWidget {
     );
   }
 
+  void _showNewsContentDialog(
+    BuildContext context, {
+    required String title,
+    required String author,
+    required String pubDate,
+    required String tag,
+    required String link,
+    required String description,
+    required List<String> detailedDescription,
+  }) {
+    showDialog(
+      context: context,
+      builder: (_) => HomeNewsContentDialogUI(
+        title: title,
+        author: author,
+        pubDate: pubDate,
+        tag: tag,
+        link: link,
+        description: description,
+        detailedDescription: detailedDescription,
+      ),
+    );
+  }
+
   Widget getRssIcon(String url) {
     if (url.startsWith("https://tieba.baidu.com")) {
       return SvgPicture.asset("assets/tieba.svg", width: 14, height: 14);
     }
 
     if (url.startsWith("https://www.bilibili.com")) {
-      return const FaIcon(FontAwesomeIcons.bilibili, size: 14, color: Color.fromRGBO(0, 161, 214, 1));
+      return const FaIcon(
+        FontAwesomeIcons.bilibili,
+        size: 14,
+        color: Color.fromRGBO(0, 161, 214, 1),
+      );
     }
 
     return const FaIcon(FontAwesomeIcons.rss, size: 14);
   }
 
-  Widget makeIndexActionLists(BuildContext context, HomeUIModel model, HomeUIModelState homeState, WidgetRef ref) {
+  Widget makeIndexActionLists(
+    BuildContext context,
+    HomeUIModel model,
+    HomeUIModelState homeState,
+    WidgetRef ref,
+  ) {
     final items = [
       _HomeItemData(
         "game_doctor",
@@ -471,7 +644,10 @@ class HomeUI extends HookConsumerWidget {
                           color: Colors.white.withValues(alpha: .2),
                           borderRadius: BorderRadius.circular(1000),
                         ),
-                        child: Padding(padding: const EdgeInsets.all(12), child: Icon(item.icon, size: 24)),
+                        child: Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: Icon(item.icon, size: 24),
+                        ),
                       ),
                       const SizedBox(width: 24),
                       Expanded(
@@ -479,20 +655,37 @@ class HomeUI extends HookConsumerWidget {
                           mainAxisSize: MainAxisSize.min,
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(item.name, style: const TextStyle(fontSize: 18)),
+                            Text(
+                              item.name,
+                              style: const TextStyle(fontSize: 18),
+                            ),
                             const SizedBox(height: 4),
                             Text(
                               item.infoString,
-                              style: TextStyle(fontSize: 14, color: Colors.white.withValues(alpha: .6)),
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: Colors.white.withValues(alpha: .6),
+                              ),
                             ),
                           ],
                         ),
                       ),
-                      if (item.key == "localization" && homeState.localizationUpdateInfo != null)
+                      if (item.key == "localization" &&
+                          homeState.localizationUpdateInfo != null)
                         Container(
-                          padding: const EdgeInsets.only(top: 3, bottom: 3, left: 8, right: 8),
-                          decoration: BoxDecoration(color: Colors.red, borderRadius: BorderRadius.circular(12)),
-                          child: Text(homeState.localizationUpdateInfo?.key ?? " "),
+                          padding: const EdgeInsets.only(
+                            top: 3,
+                            bottom: 3,
+                            left: 8,
+                            right: 8,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Colors.red,
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            homeState.localizationUpdateInfo?.key ?? " ",
+                          ),
                         ),
                       const SizedBox(width: 12),
                       const Icon(FluentIcons.chevron_right, size: 16),
@@ -552,14 +745,21 @@ class HomeUI extends HookConsumerWidget {
                           child: Text(
                             info,
                             maxLines: 1,
-                            style: TextStyle(fontSize: 12, color: Colors.white.withValues(alpha: .6)),
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.white.withValues(alpha: .6),
+                            ),
                           ),
                         ),
                     ],
                   ),
                 ),
                 const SizedBox(width: 12),
-                Icon(FluentIcons.chevron_right, size: 14, color: Colors.white.withValues(alpha: .6)),
+                Icon(
+                  FluentIcons.chevron_right,
+                  size: 14,
+                  color: Colors.white.withValues(alpha: .6),
+                ),
               ],
             ),
           ),
@@ -568,10 +768,16 @@ class HomeUI extends HookConsumerWidget {
     );
   }
 
-  Widget makeGameStatusCard(BuildContext context, HomeUIModel model, double width, HomeUIModelState homeState) {
+  Widget makeGameStatusCard(
+    BuildContext context,
+    HomeUIModel model,
+    double width,
+    HomeUIModelState homeState,
+  ) {
     final statusCnName = {
       "Platform": S.current.home_action_rsi_status_platform,
-      "Persistent Universe": S.current.home_action_rsi_status_persistent_universe,
+      "Persistent Universe":
+          S.current.home_action_rsi_status_persistent_universe,
       "Electronic Access": S.current.home_action_rsi_status_electronic_access,
       "Arena Commander": S.current.home_action_rsi_status_arena_commander,
     };
@@ -610,16 +816,25 @@ class HomeUI extends HookConsumerWidget {
                               child: Center(
                                 child: FaIcon(
                                   FontAwesomeIcons.solidCircle,
-                                  color: model.isRSIServerStatusOK(item) ? Colors.green : Colors.red,
+                                  color: model.isRSIServerStatusOK(item)
+                                      ? Colors.green
+                                      : Colors.red,
                                   size: 12,
                                 ),
                               ),
                             ),
                             const SizedBox(width: 5),
-                            Text("${statusCnName[item["name"]] ?? item["name"]}", style: const TextStyle(fontSize: 13)),
+                            Text(
+                              "${statusCnName[item["name"]] ?? item["name"]}",
+                              style: const TextStyle(fontSize: 13),
+                            ),
                           ],
                         ),
-                      Icon(FluentIcons.chevron_right, size: 12, color: Colors.white.withValues(alpha: .4)),
+                      Icon(
+                        FluentIcons.chevron_right,
+                        size: 12,
+                        color: Colors.white.withValues(alpha: .4),
+                      ),
                     ],
                   ),
               ],
@@ -630,7 +845,12 @@ class HomeUI extends HookConsumerWidget {
     );
   }
 
-  Widget makeActivityBanner(BuildContext context, HomeUIModel model, double width, HomeUIModelState homeState) {
+  Widget makeActivityBanner(
+    BuildContext context,
+    HomeUIModel model,
+    double width,
+    HomeUIModelState homeState,
+  ) {
     return Tilt(
       borderRadius: BorderRadius.circular(12),
       shadowConfig: const ShadowConfig(disable: true),
@@ -640,7 +860,12 @@ class HomeUI extends HookConsumerWidget {
           width: width + 24,
           decoration: BoxDecoration(color: FluentTheme.of(context).cardColor),
           child: Padding(
-            padding: const EdgeInsets.only(left: 12, right: 12, top: 8, bottom: 8),
+            padding: const EdgeInsets.only(
+              left: 12,
+              right: 12,
+              top: 8,
+              bottom: 8,
+            ),
             child: (homeState.countdownFestivalListData == null)
                 ? SizedBox(
                     width: width,
@@ -651,11 +876,15 @@ class HomeUI extends HookConsumerWidget {
                     width: width,
                     height: 62,
                     child: Swiper(
-                      itemCount: getMinNumber([homeState.countdownFestivalListData!.length, 6]),
+                      itemCount: getMinNumber([
+                        homeState.countdownFestivalListData!.length,
+                        6,
+                      ]),
                       autoplay: true,
                       autoplayDelay: 5000,
                       itemBuilder: (context, index) {
-                        final item = homeState.countdownFestivalListData![index];
+                        final item =
+                            homeState.countdownFestivalListData![index];
                         return Row(
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: [
@@ -672,13 +901,25 @@ class HomeUI extends HookConsumerWidget {
                             ],
                             Column(
                               children: [
-                                Text(item.name ?? "", style: const TextStyle(fontSize: 15)),
+                                Text(
+                                  item.name ?? "",
+                                  style: const TextStyle(fontSize: 15),
+                                ),
                                 const SizedBox(height: 3),
-                                CountdownTimeText(targetTime: DateTime.fromMillisecondsSinceEpoch(item.time ?? 0)),
+                                CountdownTimeText(
+                                  targetTime:
+                                      DateTime.fromMillisecondsSinceEpoch(
+                                        item.time ?? 0,
+                                      ),
+                                ),
                               ],
                             ),
                             const SizedBox(width: 12),
-                            Icon(FluentIcons.chevron_right, size: 14, color: Colors.white.withValues(alpha: .6)),
+                            Icon(
+                              FluentIcons.chevron_right,
+                              size: 14,
+                              color: Colors.white.withValues(alpha: .6),
+                            ),
                           ],
                         );
                       },
@@ -700,7 +941,9 @@ class HomeUI extends HookConsumerWidget {
           context: context,
           builder: (context) {
             return HomeMdContentDialogUI(
-              title: homeState.appPlacardData?.title ?? S.current.home_announcement_details,
+              title:
+                  homeState.appPlacardData?.title ??
+                  S.current.home_announcement_details,
               url: homeState.appPlacardData?.link,
             );
           },
@@ -710,11 +953,20 @@ class HomeUI extends HookConsumerWidget {
   }
 
   void _onTapFestival(BuildContext context) {
-    showDialog(context: context, builder: (context) => const HomeCountdownDialogUI());
+    showDialog(
+      context: context,
+      builder: (context) => const HomeCountdownDialogUI(),
+    );
   }
 
-  Future<void> _onMenuTap(BuildContext context, String key, HomeUIModelState homeState, WidgetRef ref) async {
-    String gameInstallReqInfo = S.current.home_action_info_valid_install_location_required;
+  Future<void> _onMenuTap(
+    BuildContext context,
+    String key,
+    HomeUIModelState homeState,
+    WidgetRef ref,
+  ) async {
+    String gameInstallReqInfo =
+        S.current.home_action_info_valid_install_location_required;
     switch (key) {
       case "localization":
         if (homeState.scInstalledPath == "not_install") {
@@ -787,7 +1039,8 @@ class HomeUI extends HookConsumerWidget {
         () async {
           await _onMenuTap(context, 'localization', homeState, ref);
           final localizationState = ref.read(localizationUIModelProvider);
-          if (localizationState.installedCommunityInputMethodSupportVersion != null) {
+          if (localizationState.installedCommunityInputMethodSupportVersion !=
+              null) {
             await Future.delayed(Duration(milliseconds: 300));
             if (!context.mounted) return;
             await _goInputMethod(context, model);
@@ -796,7 +1049,9 @@ class HomeUI extends HookConsumerWidget {
         }();
 
         await Future.delayed(Duration(milliseconds: 300));
-        final localizationModel = ref.read(localizationUIModelProvider.notifier);
+        final localizationModel = ref.read(
+          localizationUIModelProvider.notifier,
+        );
         if (!context.mounted) return;
         localizationModel.checkReinstall(context);
       }
@@ -806,7 +1061,10 @@ class HomeUI extends HookConsumerWidget {
   }
 
   Future<void> _goInputMethod(BuildContext context, HomeUIModel model) async {
-    await showDialog(context: context, builder: (context) => const InputMethodDialogUI());
+    await showDialog(
+      context: context,
+      builder: (context) => const InputMethodDialogUI(),
+    );
   }
 }
 

--- a/lib/ui/tools/unp4kc/widgets/audio_temp_widget.dart
+++ b/lib/ui/tools/unp4kc/widgets/audio_temp_widget.dart
@@ -59,6 +59,13 @@ class AudioTempWidget extends HookWidget {
       GlobalKey(),
     );
     final pendingSwitchToFull = useRef<bool>(false);
+    final pcmBufferChunksRef = useRef<List<Int16List>>(<Int16List>[]);
+    final pcmBufferSamplesRef = useRef<int>(0);
+    final pcmBufferTruncatedRef = useRef<bool>(false);
+    final streamSampleRateRef = useRef<int?>(null);
+    final streamChannelsRef = useRef<int?>(null);
+    final streamDurationMsRef = useRef<int>(0);
+    const maxRestartPcmBufferSeconds = 120;
 
     void syncPlayerState(AudioPlaybackState state) {
       if (state.durationMs != null) {
@@ -93,6 +100,26 @@ class AudioTempWidget extends HookWidget {
       var disposed = false;
       final currentToken = ++prepareTokenRef.value;
       pollTimerRef.value?.cancel();
+      streamStarted.value = false;
+      pendingSwitchToFull.value = false;
+      isSeeking.value = false;
+      dragMs.value = null;
+      lastPositionRef.value = 0;
+      position.value = Duration.zero;
+      duration.value = Duration.zero;
+      estimatedDuration.value = Duration.zero;
+      playablePath.value = null;
+      isDecoding.value = true;
+      isDecodeComplete.value = false;
+      errorMessage.value = null;
+      decodeProgress.value = 0.0;
+      waveform.value = <double>[];
+      streamSampleRateRef.value = null;
+      streamChannelsRef.value = null;
+      streamDurationMsRef.value = 0;
+      pcmBufferChunksRef.value = <Int16List>[];
+      pcmBufferSamplesRef.value = 0;
+      pcmBufferTruncatedRef.value = false;
 
       () async {
         try {
@@ -144,9 +171,11 @@ class AudioTempWidget extends HookWidget {
 
             if (progress.sampleRate != null) {
               sampleRate = progress.sampleRate;
+              streamSampleRateRef.value = progress.sampleRate;
             }
             if (progress.channels != null) {
               channels = progress.channels;
+              streamChannelsRef.value = progress.channels;
             }
 
             if (progress.pcmChunk != null &&
@@ -157,6 +186,21 @@ class AudioTempWidget extends HookWidget {
               final chunkDurationMs =
                   ((pcmData.length / channels) * 1000) ~/ sampleRate;
               totalDurationMs += chunkDurationMs;
+              streamDurationMsRef.value = totalDurationMs;
+              if (!pcmBufferTruncatedRef.value) {
+                final maxBufferSamples =
+                    sampleRate * channels * maxRestartPcmBufferSeconds;
+                final nextSampleCount =
+                    pcmBufferSamplesRef.value + pcmData.length;
+                if (nextSampleCount <= maxBufferSamples) {
+                  pcmBufferChunksRef.value.add(pcmData);
+                  pcmBufferSamplesRef.value = nextSampleCount;
+                } else {
+                  pcmBufferChunksRef.value = <Int16List>[];
+                  pcmBufferSamplesRef.value = 0;
+                  pcmBufferTruncatedRef.value = true;
+                }
+              }
 
               final chunkWaveform = _computeWaveformFromPcm(pcmData, 10);
               waveformSamples.addAll(chunkWaveform);
@@ -223,6 +267,7 @@ class AudioTempWidget extends HookWidget {
               }
 
               if (progress.durationMs != null) {
+                streamDurationMsRef.value = progress.durationMs!;
                 estimatedDuration.value = Duration(
                   milliseconds: progress.durationMs!,
                 );
@@ -246,8 +291,14 @@ class AudioTempWidget extends HookWidget {
               if (streamStarted.value &&
                   !disposed &&
                   prepareTokenRef.value == currentToken) {
-                pendingSwitchToFull.value = true;
-                overlayKeyRef.value.currentState?.startExitAnimation();
+                final overlayState = overlayKeyRef.value.currentState;
+                if (overlayState != null) {
+                  pendingSwitchToFull.value = true;
+                  overlayState.startExitAnimation();
+                } else {
+                  pendingSwitchToFull.value = false;
+                  isDecodeComplete.value = true;
+                }
               } else {
                 isDecodeComplete.value = true;
               }
@@ -264,9 +315,19 @@ class AudioTempWidget extends HookWidget {
       return () {
         disposed = true;
         pollTimerRef.value?.cancel();
-        unawaited(unp4k_api.p4KCancelWemDecode());
-        unawaited(audio_api.audioStopStream());
-        unawaited(player.dispose());
+        final releasedToken = currentToken;
+        Future.microtask(() async {
+          if (prepareTokenRef.value != releasedToken) return;
+          try {
+            await unp4k_api.p4KCancelWemDecode();
+          } catch (_) {}
+          try {
+            await audio_api.audioStopStream();
+          } catch (_) {}
+          try {
+            await player.dispose();
+          } catch (_) {}
+        });
       };
     }, [sourcePath]);
 
@@ -327,6 +388,68 @@ class AudioTempWidget extends HookWidget {
         : 0.0;
     final effectiveVolume = (dragVolume.value ?? volume.value).clamp(0.0, 3.0);
 
+    bool isMissingStreamError(Object error) {
+      return error.toString().contains('no streaming audio in progress');
+    }
+
+    Int16List flattenBufferedPcm() {
+      final chunks = pcmBufferChunksRef.value;
+      final sampleCount = pcmBufferSamplesRef.value;
+      final out = Int16List(sampleCount);
+      var offset = 0;
+      for (final chunk in chunks) {
+        out.setRange(offset, offset + chunk.length, chunk);
+        offset += chunk.length;
+      }
+      return out;
+    }
+
+    Future<AudioPlaybackState?> restartStreamFromBufferedPcm(
+      int targetMs, {
+      required bool autoPlayStream,
+    }) async {
+      final sampleRate = streamSampleRateRef.value;
+      final channels = streamChannelsRef.value;
+      if (sampleRate == null ||
+          channels == null ||
+          sampleRate <= 0 ||
+          channels <= 0 ||
+          pcmBufferTruncatedRef.value ||
+          pcmBufferSamplesRef.value == 0) {
+        return null;
+      }
+
+      final bufferedDurationMs =
+          (pcmBufferSamplesRef.value * 1000) ~/ (sampleRate * channels);
+      final knownDurationMs = math.max(
+        streamDurationMsRef.value,
+        math.max(totalMs, bufferedDurationMs),
+      );
+      final clampedTargetMs = targetMs.clamp(0, knownDurationMs).toInt();
+
+      var state = await audio_api.audioStartStream(
+        pcmData: flattenBufferedPcm(),
+        sampleRate: sampleRate,
+        channels: channels,
+        sourcePath: sourcePath,
+        durationMs: knownDurationMs,
+        autoPlay: autoPlayStream,
+      );
+      streamStarted.value = true;
+
+      if (clampedTargetMs > 0) {
+        state = await audio_api.audioSeekStream(positionMs: clampedTargetMs);
+        if (autoPlayStream && state.isPaused) {
+          state = await audio_api.audioResume();
+        }
+      }
+
+      playablePath.value = sourcePath;
+      duration.value = Duration(milliseconds: knownDurationMs);
+      estimatedDuration.value = Duration(milliseconds: knownDurationMs);
+      return state;
+    }
+
     Future<void> seekToPosition(
       int targetMs, {
       required bool resumeIfPlaying,
@@ -349,10 +472,16 @@ class AudioTempWidget extends HookWidget {
           lastPositionRef.value = clampedTargetMs;
         } catch (streamErr) {
           final errMsg = streamErr.toString();
-          if (errMsg.contains('no streaming audio in progress')) {
-            final state = await player.seek(
-              Duration(milliseconds: clampedTargetMs),
+          if (isMissingStreamError(streamErr)) {
+            final state = await restartStreamFromBufferedPcm(
+              clampedTargetMs,
+              autoPlayStream: resumeIfPlaying,
             );
+            if (state == null) {
+              errorMessage.value = "音频流已失效，请重新打开该音频。";
+              position.value = previousPosition;
+              return;
+            }
             if (requestId != seekRequestRef.value) return;
             syncPlayerState(state);
             position.value = Duration(milliseconds: clampedTargetMs);
@@ -403,10 +532,28 @@ class AudioTempWidget extends HookWidget {
       try {
         if (isPaused.value && !shouldReplay) {
           try {
-            final state = await audio_api.audioResume();
+            var state = await audio_api.audioResume();
+            if (!state.isPlaying && state.currentSourcePath == null) {
+              final restarted = await restartStreamFromBufferedPcm(
+                currentMs,
+                autoPlayStream: true,
+              );
+              if (restarted != null) {
+                state = restarted;
+              }
+            }
             syncPlayerState(state);
           } catch (_) {
-            final state = await player.resume();
+            var state = await player.resume();
+            if (!state.isPlaying && state.currentSourcePath == null) {
+              final restarted = await restartStreamFromBufferedPcm(
+                currentMs,
+                autoPlayStream: true,
+              );
+              if (restarted != null) {
+                state = restarted;
+              }
+            }
             syncPlayerState(state);
           }
         } else {
@@ -418,12 +565,18 @@ class AudioTempWidget extends HookWidget {
               final resumed = await audio_api.audioResume();
               syncPlayerState(resumed);
             }
-          } catch (_) {
-            final startAt = Duration(milliseconds: seekMs);
-            final state = await player.playFile(
-              playablePath.value!,
-              position: startAt,
+          } catch (e) {
+            if (!isMissingStreamError(e)) {
+              rethrow;
+            }
+            final state = await restartStreamFromBufferedPcm(
+              seekMs,
+              autoPlayStream: true,
             );
+            if (state == null) {
+              errorMessage.value = "音频流已失效，请重新打开该音频。";
+              return;
+            }
             syncPlayerState(state);
           }
         }
@@ -899,9 +1052,7 @@ class AudioTempWidget extends HookWidget {
     }
     return out;
   }
-
 }
-
 
 class _PreviewModeOverlay extends StatefulWidget {
   final VoidCallback? onComplete;

--- a/lib/ui/tools/unp4kc/widgets/dialogs.dart
+++ b/lib/ui/tools/unp4kc/widgets/dialogs.dart
@@ -242,6 +242,8 @@ class AdvancedExportProgressDialog extends HookWidget {
     final isCompleted = useState(false);
     final errorMessage = useState<String?>(null);
     final exportedCount = useState(0);
+    final failedCount = useState(0);
+    final failedExports = useRef<List<ExportFailure>>([]);
 
     useEffect(() {
       _startExport(
@@ -252,6 +254,8 @@ class AdvancedExportProgressDialog extends HookWidget {
         isCompleted,
         errorMessage,
         exportedCount,
+        failedCount,
+        failedExports.value,
       );
       return null;
     }, const []);
@@ -290,13 +294,33 @@ class AdvancedExportProgressDialog extends HookWidget {
             const SizedBox(height: 8),
             Text(errorMessage.value!),
           ] else ...[
-            const Icon(
-              FluentIcons.completed_solid,
+            Icon(
+              failedCount.value > 0
+                  ? FluentIcons.warning
+                  : FluentIcons.completed_solid,
               size: 48,
-              color: Color(0xFF107C10),
+              color: failedCount.value > 0
+                  ? const Color(0xFFFFB900)
+                  : const Color(0xFF107C10),
             ),
             const SizedBox(height: 8),
-            Text("导出完成，共 ${exportedCount.value} 个文件"),
+            Text(
+              failedCount.value > 0
+                  ? "导出完成，成功 ${exportedCount.value} 个，跳过 ${failedCount.value} 个"
+                  : "导出完成，共 ${exportedCount.value} 个文件",
+            ),
+            if (failedCount.value > 0) ...[
+              const SizedBox(height: 8),
+              Text(
+                _buildFailureSummary(failedExports.value),
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.white.withValues(alpha: .7),
+                ),
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
           ],
         ],
       ),
@@ -332,6 +356,8 @@ class AdvancedExportProgressDialog extends HookWidget {
     ValueNotifier<bool> isCompleted,
     ValueNotifier<String?> errorMessage,
     ValueNotifier<int> exportedCount,
+    ValueNotifier<int> failedCount,
+    List<ExportFailure> failedExports,
   ) async {
     try {
       final usedNames = <String, int>{};
@@ -344,27 +370,30 @@ class AdvancedExportProgressDialog extends HookWidget {
       totalFiles.value = jobs.length;
       final workerCount = _computeWorkerCount(jobs.length);
       var nextJobIndex = 0;
-      Object? firstError;
-      StackTrace? firstStack;
 
       Future<void> workerLoop() async {
         while (true) {
-          if (isCancelled.value || firstError != null) return;
+          if (isCancelled.value) return;
           if (nextJobIndex >= jobs.length) return;
 
           final job = jobs[nextJobIndex];
           nextJobIndex += 1;
           currentFile.value = job.sourcePath;
+          final outputExistedBefore = await File(job.outputPath).exists();
 
           try {
             await _exportOne(job.sourcePath, job.outputPath);
             exportedCount.value = exportedCount.value + 1;
-            currentIndex.value = exportedCount.value;
-          } catch (e, st) {
-            firstError ??= e;
-            firstStack ??= st;
-            return;
+          } catch (e) {
+            if (!outputExistedBefore) {
+              await _deletePartialOutput(job.outputPath);
+            }
+            failedExports.add(
+              ExportFailure(sourcePath: job.sourcePath, error: e.toString()),
+            );
+            failedCount.value = failedExports.length;
           }
+          currentIndex.value = currentIndex.value + 1;
         }
       }
 
@@ -374,17 +403,30 @@ class AdvancedExportProgressDialog extends HookWidget {
         errorMessage.value = S.current.tools_unp4k_extract_cancelled;
         return;
       }
-      if (firstError != null) {
-        errorMessage.value = firstStack == null
-            ? firstError.toString()
-            : "$firstError\n$firstStack";
-        return;
-      }
 
       isCompleted.value = true;
     } catch (e) {
       errorMessage.value = e.toString();
     }
+  }
+
+  Future<void> _deletePartialOutput(String outputPath) async {
+    try {
+      final file = File(outputPath);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } catch (_) {}
+  }
+
+  String _buildFailureSummary(List<ExportFailure> failures) {
+    final preview = failures
+        .take(3)
+        .map((f) => "${f.sourcePath}: ${f.error}")
+        .join("\n");
+    final rest = failures.length - 3;
+    if (rest <= 0) return preview;
+    return "$preview\n还有 $rest 个失败文件已跳过";
   }
 
   int _computeWorkerCount(int totalJobs) {

--- a/lib/ui/tools/unp4kc/widgets/models.dart
+++ b/lib/ui/tools/unp4kc/widgets/models.dart
@@ -15,6 +15,13 @@ class ExportJob {
   const ExportJob({required this.sourcePath, required this.outputPath});
 }
 
+class ExportFailure {
+  final String sourcePath;
+  final String error;
+
+  const ExportFailure({required this.sourcePath, required this.error});
+}
+
 class WaveMark {
   final double ratio;
   final int second;

--- a/rust/src/api/audio_api.rs
+++ b/rust/src/api/audio_api.rs
@@ -274,6 +274,11 @@ pub fn audio_stop() -> Result<AudioPlaybackState> {
         runtime.current_source_path = None;
         runtime.duration_ms = None;
         runtime.base_offset_ms = 0;
+        runtime.streaming_sample_offset = 0;
+        runtime.last_relative_samples = 0;
+        runtime.current_source_samples = 0;
+        runtime.streaming_config = None;
+        runtime.streaming_buffer.clear();
         Ok(build_snapshot(runtime))
     })
 }

--- a/rust/src/audio/wwise/decoder.rs
+++ b/rust/src/audio/wwise/decoder.rs
@@ -5,6 +5,7 @@ use std::sync::Once;
 
 use super::parser::parse_wem_header;
 use super::types::WwiseCodec;
+use ww2ogg::ForcePacketFormat;
 
 static INIT_RAYON: Once = Once::new();
 const CANCELLED_MSG: &str = "wem decode cancelled";
@@ -170,12 +171,67 @@ fn decode_wem_pcm_preview_to_wav(
     ))
 }
 
-fn decode_wem_vorbis_with_codebooks<F>(wem: &[u8], aotuv: bool, is_cancelled: &F) -> Result<Vec<u8>>
+#[derive(Clone, Copy)]
+struct VorbisDecodeAttempt {
+    aotuv: bool,
+    packet_format: ForcePacketFormat,
+}
+
+fn vorbis_decode_attempts() -> [VorbisDecodeAttempt; 6] {
+    [
+        VorbisDecodeAttempt {
+            aotuv: false,
+            packet_format: ForcePacketFormat::NoForce,
+        },
+        VorbisDecodeAttempt {
+            aotuv: true,
+            packet_format: ForcePacketFormat::NoForce,
+        },
+        VorbisDecodeAttempt {
+            aotuv: false,
+            packet_format: ForcePacketFormat::ForceModPackets,
+        },
+        VorbisDecodeAttempt {
+            aotuv: true,
+            packet_format: ForcePacketFormat::ForceModPackets,
+        },
+        VorbisDecodeAttempt {
+            aotuv: false,
+            packet_format: ForcePacketFormat::ForceNoModPackets,
+        },
+        VorbisDecodeAttempt {
+            aotuv: true,
+            packet_format: ForcePacketFormat::ForceNoModPackets,
+        },
+    ]
+}
+
+fn packet_format_name(format: ForcePacketFormat) -> &'static str {
+    match format {
+        ForcePacketFormat::NoForce => "auto",
+        ForcePacketFormat::ForceModPackets => "mod",
+        ForcePacketFormat::ForceNoModPackets => "no_mod",
+    }
+}
+
+fn attempt_name(attempt: VorbisDecodeAttempt) -> String {
+    format!(
+        "{}+{}",
+        if attempt.aotuv { "aotuv" } else { "default" },
+        packet_format_name(attempt.packet_format)
+    )
+}
+
+fn decode_wem_vorbis_with_codebooks<F>(
+    wem: &[u8],
+    attempt: VorbisDecodeAttempt,
+    is_cancelled: &F,
+) -> Result<Vec<u8>>
 where
     F: Fn() -> bool + Sync,
 {
     ensure_not_cancelled(is_cancelled)?;
-    let codebooks = if aotuv {
+    let codebooks = if attempt.aotuv {
         ww2ogg::CodebookLibrary::aotuv_codebooks()
     } else {
         ww2ogg::CodebookLibrary::default_codebooks()
@@ -184,7 +240,9 @@ where
 
     ensure_not_cancelled(is_cancelled)?;
     let input = Cursor::new(wem);
-    let mut converter = ww2ogg::WwiseRiffVorbis::new(input, codebooks)
+    let mut converter = ww2ogg::WwiseRiffVorbis::builder(input, codebooks)
+        .force_packet_format(attempt.packet_format)
+        .build()
         .map_err(|e| anyhow!("ww2ogg parse failed: {}", e))?;
 
     let mut ogg_bytes = Vec::<u8>::new();
@@ -199,7 +257,7 @@ where
 
 fn decode_wem_vorbis_preview_with_codebooks<F>(
     wem: &[u8],
-    aotuv: bool,
+    attempt: VorbisDecodeAttempt,
     clip_seconds: u32,
     is_cancelled: &F,
 ) -> Result<Vec<u8>>
@@ -208,7 +266,7 @@ where
 {
     ensure_not_cancelled(is_cancelled)?;
     let header = parse_wem_header(wem)?;
-    let codebooks = if aotuv {
+    let codebooks = if attempt.aotuv {
         ww2ogg::CodebookLibrary::aotuv_codebooks()
     } else {
         ww2ogg::CodebookLibrary::default_codebooks()
@@ -217,7 +275,9 @@ where
 
     ensure_not_cancelled(is_cancelled)?;
     let input = Cursor::new(wem);
-    let mut converter = ww2ogg::WwiseRiffVorbis::new(input, codebooks)
+    let mut converter = ww2ogg::WwiseRiffVorbis::builder(input, codebooks)
+        .force_packet_format(attempt.packet_format)
+        .build()
         .map_err(|e| anyhow!("ww2ogg parse failed: {}", e))?;
 
     let estimated_total_seconds = if header.avg_bytes_per_sec > 0 {
@@ -255,15 +315,14 @@ where
 {
     ensure_rayon_pool_initialized();
     ensure_not_cancelled(is_cancelled)?;
-    // We only have two viable codebook variants, so run exactly two attempts in parallel.
-    let attempts = [false, true];
+    let attempts = vorbis_decode_attempts();
     ensure_not_cancelled(is_cancelled)?;
-    let results: Vec<(bool, Result<Vec<u8>>)> = attempts
+    let results: Vec<(VorbisDecodeAttempt, Result<Vec<u8>>)> = attempts
         .par_iter()
-        .map(|aotuv| {
+        .map(|attempt| {
             (
-                *aotuv,
-                decode_wem_vorbis_with_codebooks(wem, *aotuv, is_cancelled),
+                *attempt,
+                decode_wem_vorbis_with_codebooks(wem, *attempt, is_cancelled),
             )
         })
         .collect();
@@ -273,13 +332,9 @@ where
     }
 
     let mut errs = Vec::new();
-    for (aotuv, r) in &results {
+    for (attempt, r) in &results {
         if let Err(e) = r {
-            errs.push(format!(
-                "{}={}",
-                if *aotuv { "aotuv" } else { "default" },
-                e
-            ));
+            errs.push(format!("{}={}", attempt_name(*attempt), e));
         }
     }
 
@@ -341,14 +396,18 @@ where
             "pcm wem preview cannot be converted to ogg; use wav fallback instead"
         )),
         WwiseCodec::Vorbis => {
-            // Preview decoding also has only two codebook candidates, so keep the search bounded.
-            let attempts = [false, true];
-            let results: Vec<(bool, Result<Vec<u8>>)> = attempts
+            let attempts = vorbis_decode_attempts();
+            let results: Vec<(VorbisDecodeAttempt, Result<Vec<u8>>)> = attempts
                 .par_iter()
-                .map(|aotuv| {
+                .map(|attempt| {
                     (
-                        *aotuv,
-                        decode_wem_vorbis_preview_with_codebooks(wem, *aotuv, clip_seconds, is_cancelled),
+                        *attempt,
+                        decode_wem_vorbis_preview_with_codebooks(
+                            wem,
+                            *attempt,
+                            clip_seconds,
+                            is_cancelled,
+                        ),
                     )
                 })
                 .collect();
@@ -356,13 +415,9 @@ where
                 return Ok(ogg.clone());
             }
             let mut errs = Vec::new();
-            for (aotuv, r) in &results {
+            for (attempt, r) in &results {
                 if let Err(e) = r {
-                    errs.push(format!(
-                        "{}={}",
-                        if *aotuv { "aotuv" } else { "default" },
-                        e
-                    ));
+                    errs.push(format!("{}={}", attempt_name(*attempt), e));
                 }
             }
             Err(anyhow!(


### PR DESCRIPTION
## Summary by Sourcery

Improve in-app news viewing, enhance Wwise audio streaming robustness, and make batch export handling more resilient.

New Features:
- Add an in-app news content dialog that renders HTML descriptions as markdown and shows article metadata for home news items.

Bug Fixes:
- Improve Wwise audio streaming in the temporary audio player by buffering PCM to allow stream restarts, handling missing-stream errors, and resetting streaming state correctly when stopping.
- Fix Vorbis WEM decoding by trying multiple codebook and packet-format combinations with the ww2ogg builder API to cover more file variants.
- Ensure advanced export continues past per-file failures, cleans up partial outputs, and reports skipped files instead of aborting on the first error.

Enhancements:
- Refine the home news card UX so clicking news opens a rich content dialog instead of navigating directly to external links, while keeping access to the original article.
- Improve advanced export progress feedback by tracking counts of successful and failed exports and summarizing failures in the dialog.