### PR TITLE
Agent/optimize eac registration

### DIFF
--- a/lib/common/eac/eac_registrar.dart
+++ b/lib/common/eac/eac_registrar.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const _eacDirectoryName = 'EasyAntiCheat';
+const _eacSettingsFileName = 'Settings.json';
+const _eacSetupFileName = 'EasyAntiCheat_EOS_Setup.exe';
+
+String getAntiCheatDirectory(String gameDirectory) =>
+    p.windows.join(gameDirectory, _eacDirectoryName);
+
+enum EacRegistrationOutcome { registered, distributionNotFound }
+
+class EACError implements Exception {
+  const EACError(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'EACError: $message';
+}
+
+abstract interface class EacInstallerRunner {
+  Future<void> install({required String setupPath, required String productId});
+}
+
+class DirectEacInstallerRunner implements EacInstallerRunner {
+  const DirectEacInstallerRunner({
+    this.timeout = const Duration(minutes: 2),
+  });
+
+  final Duration timeout;
+
+  @override
+  Future<void> install({
+    required String setupPath,
+    required String productId,
+  }) async {
+    final result = await Process.run(
+      setupPath,
+      ['install', productId],
+      workingDirectory: File(setupPath).parent.path,
+    ).timeout(timeout);
+    if (result.exitCode != 0) {
+      final stderr = result.stderr.toString().trim();
+      throw ProcessException(
+        setupPath,
+        ['install', productId],
+        stderr.isEmpty
+            ? 'EasyAntiCheat setup exited with code ${result.exitCode}'
+            : stderr,
+        result.exitCode,
+      );
+    }
+  }
+}
+
+class EacRegistrar {
+  EacRegistrar({EacInstallerRunner? installerRunner})
+    : _installerRunner = installerRunner ?? const DirectEacInstallerRunner();
+
+  final EacInstallerRunner _installerRunner;
+
+  Future<EacRegistrationOutcome> register({
+    required String gameDirectory,
+    void Function(String message)? log,
+  }) async {
+    final antiCheatDirectory = getAntiCheatDirectory(gameDirectory);
+    if (!await Directory(antiCheatDirectory).exists()) {
+      log?.call('No Anti-Cheat distribution was found in this build');
+      return EacRegistrationOutcome.distributionNotFound;
+    }
+
+    final productId = await _readProductId(antiCheatDirectory);
+    final setupPath = p.windows.join(antiCheatDirectory, _eacSetupFileName);
+    final identity = _gameIdentity(gameDirectory);
+    try {
+      await _installerRunner.install(
+        setupPath: setupPath,
+        productId: productId,
+      );
+    } catch (_) {
+      throw EACError(
+        'Unable to register game ${identity.gameName} with environment '
+        '${identity.environment} to the EAC service',
+      );
+    }
+    return EacRegistrationOutcome.registered;
+  }
+}
+
+Future<void> deleteAntiCheatDistribution(
+  String gameDirectory, {
+  void Function(String message)? log,
+}) async {
+  final directory = Directory(getAntiCheatDirectory(gameDirectory));
+  if (await directory.exists()) {
+    await directory.delete(recursive: true);
+  }
+  log?.call('EAC DIRECTORY SUCCESSFULLY DELETED');
+}
+
+Future<String> _readProductId(String antiCheatDirectory) async {
+  final settingsFile = File(
+    p.windows.join(antiCheatDirectory, _eacSettingsFileName),
+  );
+  final decoded = json.decode(await settingsFile.readAsString());
+  if (decoded is! Map || decoded['productid'] is! String) {
+    throw const FormatException(
+      'EasyAntiCheat Settings.json does not contain a productid',
+    );
+  }
+  final productId = (decoded['productid'] as String).trim();
+  if (productId.isEmpty) {
+    throw const FormatException(
+      'EasyAntiCheat Settings.json contains an empty productid',
+    );
+  }
+  return productId;
+}
+
+({String gameName, String environment}) _gameIdentity(String gameDirectory) {
+  final normalized = p.windows.normalize(gameDirectory);
+  return (
+    gameName: p.windows.basename(p.windows.dirname(normalized)),
+    environment: p.windows.basename(normalized),
+  );
+}

--- a/lib/common/eac/eac_registrar.dart
+++ b/lib/common/eac/eac_registrar.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -13,12 +14,15 @@ String getAntiCheatDirectory(String gameDirectory) =>
 enum EacRegistrationOutcome { registered, distributionNotFound }
 
 class EACError implements Exception {
-  const EACError(this.message);
+  const EACError(this.message, {this.cause});
 
   final String message;
+  final Object? cause;
 
   @override
-  String toString() => 'EACError: $message';
+  String toString() => cause == null
+      ? 'EACError: $message'
+      : 'EACError: $message; cause: $cause';
 }
 
 abstract interface class EacInstallerRunner {
@@ -26,9 +30,7 @@ abstract interface class EacInstallerRunner {
 }
 
 class DirectEacInstallerRunner implements EacInstallerRunner {
-  const DirectEacInstallerRunner({
-    this.timeout = const Duration(minutes: 2),
-  });
+  const DirectEacInstallerRunner({this.timeout = const Duration(minutes: 2)});
 
   final Duration timeout;
 
@@ -37,20 +39,50 @@ class DirectEacInstallerRunner implements EacInstallerRunner {
     required String setupPath,
     required String productId,
   }) async {
-    final result = await Process.run(
+    final arguments = ['install', productId];
+    final process = await Process.start(
       setupPath,
-      ['install', productId],
+      arguments,
       workingDirectory: File(setupPath).parent.path,
-    ).timeout(timeout);
-    if (result.exitCode != 0) {
-      final stderr = result.stderr.toString().trim();
+    );
+    final stdoutFuture = process.stdout
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .join();
+    final stderrFuture = process.stderr
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .join();
+    late final int exitCode;
+    try {
+      exitCode = await process.exitCode.timeout(timeout);
+    } on TimeoutException {
+      final killed = process.kill();
+      if (killed) {
+        try {
+          await process.exitCode.timeout(const Duration(seconds: 5));
+        } on TimeoutException {
+          // The timeout error below remains the actionable failure even when
+          // Windows does not report process termination promptly.
+        }
+      }
       throw ProcessException(
         setupPath,
-        ['install', productId],
-        stderr.isEmpty
-            ? 'EasyAntiCheat setup exited with code ${result.exitCode}'
-            : stderr,
-        result.exitCode,
+        arguments,
+        'EasyAntiCheat setup timed out after ${timeout.inSeconds} seconds',
+        -1,
+      );
+    }
+    final output = (await Future.wait([stderrFuture, stdoutFuture]))
+        .map((value) => value.trim())
+        .where((value) => value.isNotEmpty)
+        .join('\n');
+    if (exitCode != 0) {
+      throw ProcessException(
+        setupPath,
+        arguments,
+        output.isEmpty
+            ? 'EasyAntiCheat setup exited with code $exitCode'
+            : output,
+        exitCode,
       );
     }
   }
@@ -80,10 +112,14 @@ class EacRegistrar {
         setupPath: setupPath,
         productId: productId,
       );
-    } catch (_) {
-      throw EACError(
-        'Unable to register game ${identity.gameName} with environment '
-        '${identity.environment} to the EAC service',
+    } catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        EACError(
+          'Unable to register game ${identity.gameName} with environment '
+          '${identity.environment} to the EAC service',
+          cause: error,
+        ),
+        stackTrace,
       );
     }
     return EacRegistrationOutcome.registered;

--- a/lib/common/eac/eac_registrar.dart
+++ b/lib/common/eac/eac_registrar.dart
@@ -104,10 +104,10 @@ class EacRegistrar {
       return EacRegistrationOutcome.distributionNotFound;
     }
 
-    final productId = await _readProductId(antiCheatDirectory);
-    final setupPath = p.windows.join(antiCheatDirectory, _eacSetupFileName);
     final identity = _gameIdentity(gameDirectory);
     try {
+      final productId = await _readProductId(antiCheatDirectory);
+      final setupPath = p.windows.join(antiCheatDirectory, _eacSetupFileName);
       await _installerRunner.install(
         setupPath: setupPath,
         productId: productId,
@@ -126,15 +126,70 @@ class EacRegistrar {
   }
 }
 
-Future<void> deleteAntiCheatDistribution(
-  String gameDirectory, {
-  void Function(String message)? log,
-}) async {
-  final directory = Directory(getAntiCheatDirectory(gameDirectory));
-  if (await directory.exists()) {
-    await directory.delete(recursive: true);
+class EacDistributionPatchGuard {
+  EacDistributionPatchGuard._({
+    required this.distributionDirectory,
+    required this.backupDirectory,
+    this.log,
+  });
+
+  final Directory distributionDirectory;
+  final Directory? backupDirectory;
+  final void Function(String message)? log;
+  bool _finished = false;
+
+  static Future<EacDistributionPatchGuard> prepare(
+    String gameDirectory, {
+    void Function(String message)? log,
+  }) async {
+    final distribution = Directory(getAntiCheatDirectory(gameDirectory));
+    Directory? backup;
+    if (await distribution.exists()) {
+      backup = Directory(
+        '${distribution.path}.sctoolbox-backup-'
+        '${DateTime.now().microsecondsSinceEpoch}-$pid',
+      );
+      await distribution.rename(backup.path);
+      log?.call('EAC DIRECTORY MOVED TO ROLLBACK BACKUP');
+    }
+    return EacDistributionPatchGuard._(
+      distributionDirectory: distribution,
+      backupDirectory: backup,
+      log: log,
+    );
   }
-  log?.call('EAC DIRECTORY SUCCESSFULLY DELETED');
+
+  Future<void> commit() async {
+    if (_finished) return;
+    _finished = true;
+    final backup = backupDirectory;
+    if (backup != null && await backup.exists()) {
+      try {
+        await backup.delete(recursive: true);
+      } catch (error) {
+        log?.call('UNABLE TO DELETE EAC ROLLBACK BACKUP: $error');
+        return;
+      }
+    }
+    log?.call('EAC DIRECTORY SUCCESSFULLY DELETED');
+  }
+
+  Future<void> rollback() async {
+    if (_finished) return;
+    _finished = true;
+    try {
+      if (await distributionDirectory.exists()) {
+        await distributionDirectory.delete(recursive: true);
+      }
+      final backup = backupDirectory;
+      if (backup != null && await backup.exists()) {
+        await backup.rename(distributionDirectory.path);
+        log?.call('EAC DIRECTORY SUCCESSFULLY RESTORED');
+      }
+    } catch (error) {
+      log?.call('UNABLE TO RESTORE EAC ROLLBACK BACKUP: $error');
+    }
+  }
 }
 
 Future<String> _readProductId(String antiCheatDirectory) async {

--- a/lib/common/helper/system_helper.dart
+++ b/lib/common/helper/system_helper.dart
@@ -91,6 +91,10 @@ class SystemHelper {
     }
   }
 
+  static Future<bool> isRsiLauncherRunning() async {
+    return (await getPID("RSI Launcher")).isNotEmpty;
+  }
+
   static Future<void> checkAndLaunchRSILauncher(String path) async {
     // check running and kill
     await killRSILauncher();

--- a/lib/common/rsi_launcher/launcher_store.dart
+++ b/lib/common/rsi_launcher/launcher_store.dart
@@ -1,0 +1,372 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:path/path.dart' as p;
+import 'package:pointycastle/export.dart';
+
+const _launcherStoreSecret = 'OjPs60LNS7LbbroAuPXDkwLRipgfH6hIFA6wvuBxkg4=';
+const _ivLength = 16;
+const _separator = 0x3a;
+const _aesBlockSize = 16;
+
+class RsiLauncherStoreCodec {
+  RsiLauncherStoreCodec({Random? random}) : _random = random ?? Random.secure();
+
+  final Random _random;
+
+  Map<String, dynamic> decrypt(Uint8List payload) {
+    if (payload.length <= _ivLength + 1 || payload[_ivLength] != _separator) {
+      throw const FormatException('Unknown RSI Launcher store format');
+    }
+    final iv = Uint8List.sublistView(payload, 0, _ivLength);
+    final ciphertext = Uint8List.sublistView(payload, _ivLength + 1);
+    if (ciphertext.isEmpty || ciphertext.length % _aesBlockSize != 0) {
+      throw const FormatException('Invalid RSI Launcher store ciphertext');
+    }
+    final plaintext = _aesCbc(
+      encrypting: false,
+      key: _deriveKey(iv),
+      iv: iv,
+      input: ciphertext,
+    );
+    final decoded = json.decode(utf8.decode(_removePkcs7Padding(plaintext)));
+    if (decoded is! Map) {
+      throw const FormatException('RSI Launcher store root must be an object');
+    }
+    return Map<String, dynamic>.from(decoded);
+  }
+
+  Uint8List encrypt(Map<String, dynamic> store) {
+    final iv = Uint8List.fromList(
+      List<int>.generate(_ivLength, (_) => _random.nextInt(256)),
+    );
+    final plaintext = Uint8List.fromList(
+      utf8.encode(const JsonEncoder.withIndent('  ').convert(store)),
+    );
+    final ciphertext = _aesCbc(
+      encrypting: true,
+      key: _deriveKey(iv),
+      iv: iv,
+      input: _addPkcs7Padding(plaintext),
+    );
+    return Uint8List(iv.length + 1 + ciphertext.length)
+      ..setAll(0, iv)
+      ..[iv.length] = _separator
+      ..setAll(iv.length + 1, ciphertext);
+  }
+}
+
+class RsiLauncherStoreSyncResult {
+  const RsiLauncherStoreSyncResult({
+    required this.changed,
+    required this.backupPath,
+  });
+
+  final bool changed;
+  final String? backupPath;
+}
+
+class RsiLauncherStoreService {
+  RsiLauncherStoreService({RsiLauncherStoreCodec? codec})
+    : _codec = codec ?? RsiLauncherStoreCodec();
+
+  final RsiLauncherStoreCodec _codec;
+
+  Future<RsiLauncherStoreSyncResult> syncInstalledChannel({
+    required File storeFile,
+    required String gameDirectory,
+    required Map releaseInfo,
+    required Map libraryData,
+  }) async {
+    await _validateInstalledGame(gameDirectory);
+    final original = await storeFile.readAsBytes();
+    final store = _codec.decrypt(original);
+    final changed = updateRsiLauncherInstalledChannel(
+      store,
+      gameDirectory: gameDirectory,
+      releaseInfo: releaseInfo,
+      libraryData: libraryData,
+    );
+    if (!changed) {
+      return const RsiLauncherStoreSyncResult(changed: false, backupPath: null);
+    }
+
+    final backupFile = File('${storeFile.path}.sctoolbox.bak');
+    final tempFile = File(
+      '${storeFile.path}.sctoolbox.$pid.${DateTime.now().microsecondsSinceEpoch}.tmp',
+    );
+    await storeFile.copy(backupFile.path);
+    try {
+      await tempFile.writeAsBytes(_codec.encrypt(store), flush: true);
+      // Dart cannot replace an existing file with rename on Windows. The
+      // backup is created first and restored if the final rename fails.
+      await storeFile.delete();
+      try {
+        await tempFile.rename(storeFile.path);
+      } catch (_) {
+        if (!await storeFile.exists()) {
+          await backupFile.copy(storeFile.path);
+        }
+        rethrow;
+      }
+    } finally {
+      if (await tempFile.exists()) await tempFile.delete();
+    }
+    return RsiLauncherStoreSyncResult(
+      changed: true,
+      backupPath: backupFile.path,
+    );
+  }
+}
+
+bool updateRsiLauncherInstalledChannel(
+  Map<String, dynamic> store, {
+  required String gameDirectory,
+  required Map releaseInfo,
+  required Map libraryData,
+}) {
+  final before = json.encode(store);
+  final library = _requiredMap(store, 'library');
+  final installed = _requiredList(library, 'installed');
+  final environment = p.windows.basename(p.windows.normalize(gameDirectory));
+  final serverGame = _findGame(_gamesFromLibraryData(libraryData), null);
+  final serverChannel = serverGame == null
+      ? null
+      : _findChannel(_channels(serverGame), environment);
+  final game = _findGame(installed, serverGame);
+
+  final targetGame = game ?? _newGame(serverGame);
+  final channels = _channels(targetGame);
+  final currentChannel = _findChannel(channels, environment);
+  if (currentChannel == null && serverChannel == null) {
+    throw StateError('No $environment channel metadata was found');
+  }
+
+  final channel = <String, dynamic>{
+    if (currentChannel != null) ...currentChannel,
+    if (serverChannel != null) ...serverChannel,
+  };
+  _overlayReleaseMetadata(channel, releaseInfo);
+  channel['id'] = environment;
+  channel['status'] = 'installed';
+  final installRoot = p.windows.dirname(p.windows.normalize(gameDirectory));
+  channel['installDir'] = p.windows.basename(installRoot);
+  channel['libraryFolder'] = _withTrailingSeparator(
+    p.windows.dirname(installRoot),
+  );
+  channel.putIfAbsent('network', () => null);
+  _normalizeVersion(channel);
+  _validateChannel(channel);
+
+  final channelIndex = channels.indexWhere(
+    (value) => _mapId(value)?.toUpperCase() == environment.toUpperCase(),
+  );
+  if (channelIndex < 0) {
+    channels.add(channel);
+  } else {
+    channels[channelIndex] = channel;
+  }
+  targetGame['channels'] = channels;
+  if (game == null) {
+    installed.add(targetGame);
+  } else {
+    final gameId = _mapId(game)?.toUpperCase();
+    final gameIndex = installed.indexWhere(
+      (value) => value is Map && _mapId(value)?.toUpperCase() == gameId,
+    );
+    if (gameIndex < 0) {
+      throw StateError('Installed Star Citizen record disappeared');
+    }
+    installed[gameIndex] = targetGame;
+  }
+  library['installed'] = installed;
+  store['library'] = library;
+  return before != json.encode(store);
+}
+
+Uint8List _deriveKey(Uint8List iv) {
+  // Node's Buffer.toString() decodes the raw IV as UTF-8 with replacement
+  // characters. pbkdf2Sync then encodes that JavaScript string as UTF-8 again.
+  final saltText = utf8.decode(iv, allowMalformed: true);
+  final derivator = PBKDF2KeyDerivator(HMac(SHA512Digest(), 128))
+    ..init(
+      Pbkdf2Parameters(Uint8List.fromList(utf8.encode(saltText)), 10000, 32),
+    );
+  return derivator.process(
+    Uint8List.fromList(utf8.encode(_launcherStoreSecret)),
+  );
+}
+
+Uint8List _aesCbc({
+  required bool encrypting,
+  required Uint8List key,
+  required Uint8List iv,
+  required Uint8List input,
+}) {
+  final cipher = CBCBlockCipher(AESEngine())
+    ..init(encrypting, ParametersWithIV(KeyParameter(key), iv));
+  final output = Uint8List(input.length);
+  for (var offset = 0; offset < input.length; offset += _aesBlockSize) {
+    cipher.processBlock(input, offset, output, offset);
+  }
+  return output;
+}
+
+Uint8List _addPkcs7Padding(Uint8List input) {
+  final count = _aesBlockSize - input.length % _aesBlockSize;
+  return Uint8List(input.length + count)
+    ..setAll(0, input)
+    ..fillRange(input.length, input.length + count, count);
+}
+
+Uint8List _removePkcs7Padding(Uint8List input) {
+  if (input.isEmpty) throw const FormatException('Invalid PKCS7 padding');
+  final count = input.last;
+  if (count < 1 || count > _aesBlockSize || count > input.length) {
+    throw const FormatException('Invalid PKCS7 padding');
+  }
+  for (var index = input.length - count; index < input.length; index++) {
+    if (input[index] != count) {
+      throw const FormatException('Invalid PKCS7 padding');
+    }
+  }
+  return Uint8List.sublistView(input, 0, input.length - count);
+}
+
+Future<void> _validateInstalledGame(String gameDirectory) async {
+  if (await File(p.windows.join(gameDirectory, 'Data.p4k.part')).exists()) {
+    throw StateError('Data.p4k is still incomplete');
+  }
+  if (!await File(p.windows.join(gameDirectory, 'Data.p4k')).exists()) {
+    throw StateError('Data.p4k was not found');
+  }
+}
+
+Map<String, dynamic> _requiredMap(Map source, String key) {
+  final value = source[key];
+  if (value is! Map) throw FormatException('$key must be an object');
+  return Map<String, dynamic>.from(value);
+}
+
+List<dynamic> _requiredList(Map source, String key) {
+  final value = source[key];
+  if (value is! List) throw FormatException('$key must be an array');
+  return List<dynamic>.from(value);
+}
+
+List<dynamic> _gamesFromLibraryData(Map libraryData) {
+  final games = libraryData['games'];
+  return games is List ? games : const [];
+}
+
+Map<String, dynamic>? _findGame(List<dynamic> games, Map? template) {
+  final templateId = _mapId(template)?.toUpperCase();
+  for (final value in games) {
+    if (value is! Map) continue;
+    final id = _mapId(value)?.toUpperCase();
+    final name = value['name']?.toString().toLowerCase();
+    if ((templateId != null && id == templateId) ||
+        id == 'SC' ||
+        name == 'star citizen') {
+      return Map<String, dynamic>.from(value);
+    }
+  }
+  return null;
+}
+
+Map<String, dynamic>? _findChannel(
+  List<Map<String, dynamic>> channels,
+  String environment,
+) {
+  for (final channel in channels) {
+    if (_mapId(channel)?.toUpperCase() == environment.toUpperCase()) {
+      return Map<String, dynamic>.from(channel);
+    }
+  }
+  return null;
+}
+
+List<Map<String, dynamic>> _channels(Map game) {
+  final values = game['channels'];
+  if (values is! List) return [];
+  return values
+      .whereType<Map>()
+      .map((value) => Map<String, dynamic>.from(value))
+      .toList();
+}
+
+Map<String, dynamic> _newGame(Map<String, dynamic>? serverGame) {
+  if (serverGame == null) {
+    throw StateError('Star Citizen library metadata was not found');
+  }
+  return {
+    'id': serverGame['id'],
+    'name': serverGame['name'],
+    'channels': <Map<String, dynamic>>[],
+  };
+}
+
+void _overlayReleaseMetadata(Map<String, dynamic> channel, Map releaseInfo) {
+  const fields = [
+    'name',
+    'version',
+    'versionLabel',
+    'platformId',
+    'servicesEndpoint',
+    'nid',
+    'network',
+    'weight',
+  ];
+  for (final field in fields) {
+    if (releaseInfo[field] != null) channel[field] = releaseInfo[field];
+  }
+  if (releaseInfo['version'] == null && releaseInfo['versionLabel'] != null) {
+    channel['version'] = releaseInfo['versionLabel'];
+  }
+}
+
+void _normalizeVersion(Map<String, dynamic> channel) {
+  final version = channel['version'];
+  if (version is num) return;
+  final direct = int.tryParse(version?.toString() ?? '');
+  if (direct != null) {
+    channel['version'] = direct;
+    return;
+  }
+  final label = channel['versionLabel']?.toString() ?? '';
+  final matches = RegExp(r'(\d+)').allMatches(label).toList();
+  if (matches.isNotEmpty) {
+    channel['version'] = int.tryParse(matches.last.group(1)!);
+  }
+}
+
+void _validateChannel(Map<String, dynamic> channel) {
+  const stringFields = [
+    'id',
+    'name',
+    'versionLabel',
+    'platformId',
+    'servicesEndpoint',
+    'status',
+    'installDir',
+    'libraryFolder',
+  ];
+  for (final field in stringFields) {
+    if (channel[field] is! String || (channel[field] as String).isEmpty) {
+      throw FormatException('Channel $field must be a non-empty string');
+    }
+  }
+  if (channel['version'] is! num) {
+    throw const FormatException('Channel version must be a number');
+  }
+  if (!channel.containsKey('network')) {
+    throw const FormatException('Channel network is required');
+  }
+}
+
+String? _mapId(Map? value) => value?['id']?.toString();
+
+String _withTrailingSeparator(String value) =>
+    value.endsWith('\\') ? value : '$value\\';

--- a/lib/common/rsi_launcher/launcher_store.dart
+++ b/lib/common/rsi_launcher/launcher_store.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -82,7 +83,7 @@ class RsiLauncherStoreService {
   }) async {
     await _validateInstalledGame(gameDirectory);
     final original = await storeFile.readAsBytes();
-    final store = _codec.decrypt(original);
+    final store = await Isolate.run(() => _codec.decrypt(original));
     final changed = updateRsiLauncherInstalledChannel(
       store,
       gameDirectory: gameDirectory,
@@ -99,7 +100,8 @@ class RsiLauncherStoreService {
     );
     await storeFile.copy(backupFile.path);
     try {
-      await tempFile.writeAsBytes(_codec.encrypt(store), flush: true);
+      final encrypted = await Isolate.run(() => _codec.encrypt(store));
+      await tempFile.writeAsBytes(encrypted, flush: true);
       // Dart cannot replace an existing file with rename on Windows. The
       // backup is created first and restored if the final rename fails.
       await storeFile.delete();
@@ -335,7 +337,14 @@ void _normalizeVersion(Map<String, dynamic> channel) {
     channel['version'] = direct;
     return;
   }
-  final label = channel['versionLabel']?.toString() ?? '';
+  var versionLabel = channel['versionLabel']?.toString() ?? '';
+  if (versionLabel.isEmpty && version is String && version.isNotEmpty) {
+    versionLabel = version;
+    channel['versionLabel'] = versionLabel;
+  }
+  final label = versionLabel.isNotEmpty
+      ? versionLabel
+      : version?.toString() ?? '';
   final matches = RegExp(r'(\d+)').allMatches(label).toList();
   if (matches.isNotEmpty) {
     channel['version'] = int.tryParse(matches.last.group(1)!);

--- a/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
+++ b/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:starcitizen_doctor/common/eac/eac_registrar.dart';
 import 'package:starcitizen_doctor/common/rust/api/p4k_upgrader_api.dart';
 import 'package:starcitizen_doctor/ui/home/dialogs/home_p4k_download_source_dialog_ui.dart';
 import 'package:starcitizen_doctor/widgets/widgets.dart';
@@ -467,6 +468,12 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
       task: () async {
         _paused = false;
         _cancelling = false;
+        if (config.updateLooseFiles) {
+          await deleteAntiCheatDistribution(
+            widget.installPath,
+            log: _appendEacLog,
+          );
+        }
         _startDownloadSpeedTimer();
         final completer = Completer<void>();
         late final StreamSubscription<P4kUpgraderProgressEvent> sub;
@@ -1039,10 +1046,11 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
   }
 
   Future<void> _installEasyAntiCheat(String stageText) async {
-    final eacDir = Directory(_joinInstallPath('EasyAntiCheat'));
-    final eacExe = File(_joinPath(eacDir.path, 'EasyAntiCheat_EOS_Setup.exe'));
-    const eacId = '54540c7a80fe48ea92ead64506b4ff53';
-    if (!await eacExe.exists()) {
+    final outcome = await EacRegistrar().register(
+      gameDirectory: widget.installPath,
+      log: _appendEacLog,
+    );
+    if (outcome == EacRegistrationOutcome.distributionNotFound) {
       _setPostInstallStatus(
         stageText,
         S
@@ -1054,40 +1062,13 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
     }
     _setPostInstallStatus(
       stageText,
-      S.current.p4k_update_registering_easyanticheat,
+      S.current.p4k_update_easyanticheat_registration_completed,
     );
-    try {
-      final result = await Process.run(eacExe.path, const [
-        'install',
-        eacId,
-      ], workingDirectory: eacDir.path).timeout(const Duration(minutes: 2));
-      if (result.exitCode == 0) {
-        _setPostInstallStatus(
-          stageText,
-          S.current.p4k_update_easyanticheat_registration_completed,
-        );
-      } else {
-        final detail = _processOutputSummary(result);
-        _setPostInstallStatus(
-          stageText,
-          S.current
-              .p4k_update_easyanticheat_registration_returned_has_continued_as_a_non_fatal(
-                result.exitCode,
-                detail,
-              ),
-          warning: true,
-        );
-      }
-    } catch (e) {
-      _setPostInstallStatus(
-        stageText,
-        S.current
-            .p4k_update_easyanticheat_registration_failed_and_has_continued_as_a_non_fat(
-              e,
-            ),
-        warning: true,
-      );
-    }
+  }
+
+  void _appendEacLog(String message) {
+    if (!mounted) return;
+    setState(() => _appendLogLine('${_simpleLogTime()} $message'));
   }
 
   Future<void> _syncLauncherInstallState(String stageText) async {
@@ -1788,18 +1769,6 @@ String? _lastNumberString(String value) {
   final matches = RegExp(r'(\d{5,})').allMatches(value).toList();
   if (matches.isEmpty) return null;
   return matches.last.group(1);
-}
-
-String _processOutputSummary(ProcessResult result) {
-  final output = [
-    result.stdout?.toString().trim() ?? '',
-    result.stderr?.toString().trim() ?? '',
-  ].where((value) => value.isNotEmpty).join(' ');
-  if (output.isEmpty) return "";
-  final clipped = output.length > 300
-      ? '${output.substring(0, 300)}...'
-      : output;
-  return "：$clipped";
 }
 
 String _simpleLogTime() {

--- a/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
+++ b/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
@@ -476,8 +476,9 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
       task: () async {
         _paused = false;
         _cancelling = false;
+        EacDistributionPatchGuard? eacPatchGuard;
         if (config.updateLooseFiles) {
-          await deleteAntiCheatDistribution(
+          eacPatchGuard = await EacDistributionPatchGuard.prepare(
             widget.installPath,
             log: _appendEacLog,
           );
@@ -623,9 +624,12 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
         try {
           await completer.future;
           if (streamCompletedSuccessfully && !_cancelling) {
+            await eacPatchGuard?.commit();
+            eacPatchGuard = null;
             await _runPostInstallTasks();
           }
         } finally {
+          await eacPatchGuard?.rollback();
           _stopDownloadSpeedTimer();
           await sub.cancel();
           if (mounted) {
@@ -1066,10 +1070,24 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
   }
 
   Future<void> _installEasyAntiCheat(String stageText) async {
-    final outcome = await EacRegistrar().register(
-      gameDirectory: widget.installPath,
-      log: _appendEacLog,
-    );
+    late final EacRegistrationOutcome outcome;
+    try {
+      outcome = await EacRegistrar().register(
+        gameDirectory: widget.installPath,
+        log: _appendEacLog,
+      );
+    } on EACError catch (error) {
+      _appendEacLog(error.toString());
+      _setPostInstallStatus(
+        stageText,
+        S.current
+            .p4k_update_easyanticheat_registration_failed_and_has_continued_as_a_non_fat(
+              error,
+            ),
+        warning: true,
+      );
+      return;
+    }
     if (outcome == EacRegistrationOutcome.distributionNotFound) {
       _setPostInstallStatus(
         stageText,

--- a/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
+++ b/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
@@ -246,7 +246,7 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
         ),
         if (_working)
           Button(
-            onPressed: _cancelling ? null : _togglePause,
+            onPressed: _cancelling ? null : () => _togglePause(context),
             child: Text(
               _paused
                   ? S.current.app_splash_free_software_notice_confirm
@@ -425,11 +425,13 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
   }
 
   Future<void> _runUpdate(BuildContext context) async {
+    if (await _blockUpdateWhileLauncherIsRunning(context)) return;
+    if (!mounted) return;
     final config = _buildConfig();
     if (config == null) return;
     _prepareStagePlan(deepRepair: false);
     await _runUpdateWithProgressTask(
-      context,
+      this.context,
       config,
       status:
           S.current.p4k_update_downloading_objects_game_files_and_patching_p4k,
@@ -439,11 +441,13 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
   }
 
   Future<void> _runRepairMode(BuildContext context) async {
+    if (await _blockUpdateWhileLauncherIsRunning(context)) return;
+    if (!mounted) return;
     final config = _buildConfig(deepVerify: true);
     if (config == null) return;
     _prepareStagePlan(deepRepair: true);
     await _runUpdateWithProgressTask(
-      context,
+      this.context,
       config,
       status: S
           .current
@@ -636,6 +640,17 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
     );
   }
 
+  Future<bool> _blockUpdateWhileLauncherIsRunning(BuildContext context) async {
+    if (!await blockIfRsiLauncherRunning(context)) return false;
+    if (mounted) {
+      setState(
+        () =>
+            _status = S.current.tools_action_info_rsi_launcher_running_warning,
+      );
+    }
+    return true;
+  }
+
   void _stopUpdate() {
     if (_cancelling) return;
     p4KUpgraderCancel();
@@ -648,9 +663,10 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
     });
   }
 
-  void _togglePause() {
+  Future<void> _togglePause(BuildContext context) async {
     if (_cancelling) return;
     if (_paused) {
+      if (await _blockUpdateWhileLauncherIsRunning(context)) return;
       p4KUpgraderResume();
     } else {
       p4KUpgraderPause();
@@ -1104,12 +1120,8 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
       const message =
           'RSI Launcher is running; exit it completely before synchronizing '
           'launcher store.json';
-      _setPostInstallStatus(
-        stageText,
-        message,
-        warning: true,
-      );
-      throw StateError(message);
+      _setPostInstallStatus(stageText, message, warning: true);
+      return;
     }
     try {
       final result = await RsiLauncherStoreService().syncInstalledChannel(
@@ -1136,7 +1148,6 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
         'RSI Launcher store synchronization failed: $error',
         warning: true,
       );
-      rethrow;
     }
   }
 

--- a/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
+++ b/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:starcitizen_doctor/common/eac/eac_registrar.dart';
+import 'package:starcitizen_doctor/common/helper/system_helper.dart';
+import 'package:starcitizen_doctor/common/rsi_launcher/launcher_store.dart';
 import 'package:starcitizen_doctor/common/rust/api/p4k_upgrader_api.dart';
 import 'package:starcitizen_doctor/ui/home/dialogs/home_p4k_download_source_dialog_ui.dart';
 import 'package:starcitizen_doctor/widgets/widgets.dart';
@@ -29,6 +31,7 @@ class HomeP4kUpdateDialogUI extends StatefulWidget {
     required this.applicationSupportDir,
     required this.webToken,
     required this.webCookie,
+    this.libraryData = const {},
     this.onMirrorProviderError,
   });
 
@@ -38,6 +41,7 @@ class HomeP4kUpdateDialogUI extends StatefulWidget {
   final String applicationSupportDir;
   final String webToken;
   final String webCookie;
+  final Map libraryData;
   final Future<bool> Function(P4kMirrorUnavailable error)?
   onMirrorProviderError;
 
@@ -1077,6 +1081,14 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
       S.current.p4k_update_synchronizing_launcher_installation_status,
     );
     final buildManifestUpdated = await _updateBuildManifestId(stageText);
+    if (widget.releaseInfo.isEmpty) {
+      _setPostInstallStatus(
+        stageText,
+        'RSI Launcher store sync skipped: official release metadata is missing',
+        warning: true,
+      );
+      return;
+    }
     final storeCandidates = await _existingLauncherStoreCandidates();
     if (storeCandidates.isEmpty) {
       _setPostInstallStatus(
@@ -1086,18 +1098,45 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
             .p4k_update_rsi_launcher_store_not_found_encrypted_store_sync_skipped,
         warning: true,
       );
-    } else {
-      final suffix = buildManifestUpdated
-          ? S.current.p4k_update_build_manifest_id_updated
-          : "";
+      return;
+    }
+    if ((await SystemHelper.getPID('RSI Launcher')).isNotEmpty) {
+      const message =
+          'RSI Launcher is running; exit it completely before synchronizing '
+          'launcher store.json';
       _setPostInstallStatus(
         stageText,
-        S.current
-            .p4k_update_encryption_rsi_launcher_store_synchronization_is_not_executed_th(
-              suffix,
-            ),
+        message,
         warning: true,
       );
+      throw StateError(message);
+    }
+    try {
+      final result = await RsiLauncherStoreService().syncInstalledChannel(
+        storeFile: storeCandidates.first,
+        gameDirectory: widget.installPath,
+        releaseInfo: widget.releaseInfo,
+        libraryData: widget.libraryData,
+      );
+      final manifestSuffix = buildManifestUpdated
+          ? '; build_manifest.id updated'
+          : '';
+      final backupSuffix = result.backupPath == null
+          ? ''
+          : '; backup: ${result.backupPath}';
+      _setPostInstallStatus(
+        stageText,
+        result.changed
+            ? 'RSI Launcher store synchronized$manifestSuffix$backupSuffix'
+            : 'RSI Launcher store is already up to date$manifestSuffix',
+      );
+    } catch (error) {
+      _setPostInstallStatus(
+        stageText,
+        'RSI Launcher store synchronization failed: $error',
+        warning: true,
+      );
+      rethrow;
     }
   }
 
@@ -1125,9 +1164,10 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
       final data = root['Data'] is Map
           ? Map<String, dynamic>.from(root['Data'] as Map)
           : <String, dynamic>{};
-      data['Branch'] = data['Branch'] ?? 'LIVE';
-      data['RequestedP4ChangeNum'] = int.tryParse(changeNumber) ?? changeNumber;
-      data['BuildId'] = data['BuildId'] ?? data['RequestedP4ChangeNum'];
+      final buildNumber = int.tryParse(changeNumber) ?? changeNumber;
+      data['Branch'] = _installEnvironment(widget.installPath);
+      data['RequestedP4ChangeNum'] = buildNumber;
+      data['BuildId'] = buildNumber;
       root['Data'] = data;
       await file.writeAsString(
         const JsonEncoder.withIndent('  ').convert(root),
@@ -1153,23 +1193,12 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
   }
 
   Future<List<File>> _existingLauncherStoreCandidates() async {
-    final roots = [
-      Platform.environment['APPDATA'],
-      Platform.environment['LOCALAPPDATA'],
-    ].whereType<String>().where((value) => value.isNotEmpty);
-    const relative = [
-      ['rsilauncher', 'launcher store.json'],
-      ['RSI Launcher', 'launcher store.json'],
-      ['UI Launcher', 'launcher store.json'],
-    ];
-    final files = <File>[];
-    for (final root in roots) {
-      for (final parts in relative) {
-        final file = File(_joinPath(root, _joinPath(parts[0], parts[1])));
-        if (await file.exists()) files.add(file);
-      }
-    }
-    return files;
+    final appData = Platform.environment['APPDATA'];
+    if (appData == null || appData.isEmpty) return const [];
+    final file = File(
+      _joinPath(appData, _joinPath('rsilauncher', 'launcher store.json')),
+    );
+    return await file.exists() ? [file] : const [];
   }
 
   void _setPostInstallStatus(
@@ -1732,9 +1761,13 @@ String _stageLabelForKey(String key) {
 }
 
 bool _isLiveInstallPath(String path) {
+  return _installEnvironment(path) == 'LIVE';
+}
+
+String _installEnvironment(String path) {
   final normalized = path.replaceAll('\\', '/').replaceAll(RegExp(r'/+$'), '');
-  if (normalized.isEmpty) return false;
-  return normalized.split('/').last.toUpperCase() == 'LIVE';
+  if (normalized.isEmpty) return '';
+  return normalized.split('/').last.toUpperCase();
 }
 
 String get _p4kLiveOnlyMessage => S

--- a/lib/ui/home/downloader/home_downloader_ui.dart
+++ b/lib/ui/home/downloader/home_downloader_ui.dart
@@ -165,7 +165,7 @@ class HomeDownloaderUI extends HookConsumerWidget {
                                     MenuFlyoutItem(
                                       leading: const Icon(FluentIcons.download),
                                       text: Text(S.current.downloader_action_continue_download),
-                                      onPressed: () => model.resumeTask(task.id.toInt()),
+                                      onPressed: () => model.resumeTask(context, task.id.toInt()),
                                     )
                                   else if (isActive)
                                     MenuFlyoutItem(

--- a/lib/ui/home/downloader/home_downloader_ui_model.dart
+++ b/lib/ui/home/downloader/home_downloader_ui_model.dart
@@ -27,7 +27,6 @@ abstract class HomeDownloaderUIState with _$HomeDownloaderUIState {
     DownloadGlobalStat? globalStat,
   }) = _HomeDownloaderUIState;
 }
-
 extension HomeDownloaderUIStateExtension on HomeDownloaderUIState {
   bool get isAvailable => globalStat != null;
 }
@@ -74,6 +73,10 @@ class HomeDownloaderUIModel extends _$HomeDownloaderUIModel {
         return;
       case "resume_all":
         if (!downloadManagerState.isRunning) return;
+        if (_containsGameFileTask(state.waitingTasks) &&
+            await blockIfRsiLauncherRunning(context)) {
+          return;
+        }
         await downloadManager.resumeAll();
         return;
       case "cancel_all":
@@ -175,9 +178,21 @@ class HomeDownloaderUIModel extends _$HomeDownloaderUIModel {
     return S.current.downloader_info_checking_progress(percent);
   }
 
-  Future<void> resumeTask(int taskId) async {
+  Future<void> resumeTask(BuildContext context, int taskId) async {
+    final isGameFileTask = state.waitingTasks.any(
+      (task) => task.id.toInt() == taskId && _isGameFileTask(task),
+    );
+    if (isGameFileTask && await blockIfRsiLauncherRunning(context)) return;
     final downloadManager = ref.read(downloadManagerProvider.notifier);
     await downloadManager.resumeTask(taskId);
+  }
+
+  bool _containsGameFileTask(Iterable<DownloadTaskInfo> tasks) {
+    return tasks.any(_isGameFileTask);
+  }
+
+  bool _isGameFileTask(DownloadTaskInfo task) {
+    return task.name.toLowerCase() == 'data.p4k';
   }
 
   Future<void> pauseTask(int taskId) async {

--- a/lib/ui/home/game_doctor/game_doctor_ui_model.dart
+++ b/lib/ui/home/game_doctor/game_doctor_ui_model.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:starcitizen_doctor/common/eac/eac_registrar.dart';
 import 'package:starcitizen_doctor/common/helper/log_helper.dart';
 import 'package:starcitizen_doctor/common/helper/system_helper.dart';
 import 'package:starcitizen_doctor/common/rust/api/win32_api.dart' as win32;
@@ -73,22 +74,22 @@ class HomeGameDoctorUIModel extends _$HomeGameDoctorUIModel {
         showToast(context, S.current.doctor_info_result_verify_files_with_rsi_launcher);
         break;
       case "eac_not_install":
-        final eacJsonPath = "${item.value}\\Settings.json";
-        final eacJsonData = await File(eacJsonPath).readAsBytes();
-        final Map eacJson = json.decode(utf8.decode(eacJsonData));
-        final eacID = eacJson["productid"];
         try {
-          var result = await Process.run("${item.value}\\EasyAntiCheat_EOS_Setup.exe", ["install", eacID]);
-          dPrint("${item.value}\\EasyAntiCheat_EOS_Setup.exe install $eacID");
-          if (result.stderr == "") {
-            if (!context.mounted) break;
-            showToast(context, S.current.doctor_action_result_game_start_success);
-            checkResult.remove(item);
-            state = state.copyWith(checkResult: checkResult);
-          } else {
-            if (!context.mounted) break;
-            showToast(context, S.current.doctor_action_result_fix_fail(result.stderr));
+          final outcome = await EacRegistrar().register(
+            gameDirectory: Directory(item.value).parent.path,
+            log: dPrint,
+          );
+          if (!context.mounted) break;
+          if (outcome == EacRegistrationOutcome.distributionNotFound) {
+            showToast(
+              context,
+              S.current.doctor_info_result_verify_files_with_rsi_launcher,
+            );
+            break;
           }
+          showToast(context, S.current.doctor_action_result_game_start_success);
+          checkResult.remove(item);
+          state = state.copyWith(checkResult: checkResult);
         } catch (e) {
           if (!context.mounted) break;
           showToast(context, S.current.doctor_action_result_fix_fail(e));

--- a/lib/ui/home/home_ui_model.dart
+++ b/lib/ui/home/home_ui_model.dart
@@ -16,8 +16,6 @@ import 'package:starcitizen_doctor/common/helper/log_helper.dart';
 import 'package:starcitizen_doctor/common/io/rs_http.dart';
 import 'package:starcitizen_doctor/common/rust/api/win32_api.dart' as win32;
 import 'package:starcitizen_doctor/common/rust/api/p4k_upgrader_api.dart';
-import 'package:starcitizen_doctor/common/utils/async.dart';
-import 'package:starcitizen_doctor/common/utils/base_utils.dart';
 import 'package:starcitizen_doctor/common/utils/log.dart';
 import 'package:starcitizen_doctor/common/utils/provider.dart';
 import 'package:starcitizen_doctor/data/app_placard_data.dart';
@@ -28,6 +26,7 @@ import 'package:starcitizen_doctor/ui/home/dialogs/home_game_login_dialog_ui.dar
 import 'package:starcitizen_doctor/ui/home/dialogs/home_p4k_update_dialog_ui.dart';
 import 'package:starcitizen_doctor/ui/home/dialogs/home_p4k_download_source_dialog_ui.dart';
 import 'package:starcitizen_doctor/ui/home/p4k_source_session_coordinator.dart';
+import 'package:starcitizen_doctor/widgets/widgets.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:html/parser.dart' as html;
 import 'package:html/dom.dart' as html_dom;
@@ -423,6 +422,7 @@ class HomeUIModel extends _$HomeUIModel {
 
   // ignore: avoid_build_context_in_providers
   Future<void> openP4kUpdater(BuildContext context) async {
+    if (await blockIfRsiLauncherRunning(context)) return;
     await openP4kUpdaterSession(
       selectSource: () => showP4kDownloadSourceDialog(context),
       openOfficial: () => context.mounted

--- a/lib/ui/home/home_ui_model.dart
+++ b/lib/ui/home/home_ui_model.dart
@@ -511,6 +511,9 @@ class HomeUIModel extends _$HomeUIModel {
         }
         final data = message["data"];
         final releaseInfo = data is Map ? data["releaseInfo"] : null;
+        final libraryData = data is Map && data["libraryData"] is Map
+            ? data["libraryData"] as Map
+            : const {};
         final webToken = data is Map ? data["webToken"]?.toString() ?? "" : "";
         final webCookie = data is Map
             ? data["webCookie"]?.toString() ?? ""
@@ -537,6 +540,7 @@ class HomeUIModel extends _$HomeUIModel {
             applicationSupportDir: appGlobalState.applicationSupportDir!,
             webToken: webToken,
             webCookie: _mergeCookieHeaders([webCookie, webViewCookies]),
+            libraryData: libraryData,
           ),
         );
         if (result == P4kUpdateDialogResult.updated) {

--- a/lib/ui/tools/tools_ui_model.dart
+++ b/lib/ui/tools/tools_ui_model.dart
@@ -724,17 +724,7 @@ class ToolsUIModel extends _$ToolsUIModel {
   Future<void> _downloadP4k(BuildContext context, String torrentUrl) async {
     String savePath = state.scInstalledPath;
 
-    if ((await SystemHelper.getPID("RSI Launcher")).isNotEmpty) {
-      if (!context.mounted) return;
-      showToast(
-        context,
-        S.current.tools_action_info_rsi_launcher_running_warning,
-        constraints: BoxConstraints(
-          maxWidth: MediaQuery.of(context).size.width * .35,
-        ),
-      );
-      return;
-    }
+    if (await blockIfRsiLauncherRunning(context)) return;
 
     if (!context.mounted) return;
     final ok = await showConfirmDialogs(

--- a/lib/widgets/src/rsi_launcher_guard.dart
+++ b/lib/widgets/src/rsi_launcher_guard.dart
@@ -1,0 +1,17 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:starcitizen_doctor/common/helper/system_helper.dart';
+import 'package:starcitizen_doctor/common/utils/base_utils.dart';
+import 'package:starcitizen_doctor/generated/l10n.dart';
+
+/// Shows the standard warning and returns true when a game-file operation
+/// must be blocked because RSI Launcher is still running.
+Future<bool> blockIfRsiLauncherRunning(BuildContext context) async {
+  if (!await SystemHelper.isRsiLauncherRunning()) return false;
+  if (context.mounted) {
+    showToast(
+      context,
+      S.current.tools_action_info_rsi_launcher_running_warning,
+    );
+  }
+  return true;
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -17,6 +17,7 @@ export 'src/cache_image.dart';
 export 'src/countdown_time_text.dart';
 export 'src/cache_svg_image.dart';
 export 'src/grid_item_animator.dart';
+export 'src/rsi_launcher_guard.dart';
 export 'src/swiper.dart';
 
 export '../common/utils/async.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1021,6 +1021,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: "direct main"
+    description:
+      name: pointycastle
+      sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   pool:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   watcher: ^1.2.1
   path: ^1.9.1
   crypto: ^3.0.7
+  pointycastle: ^4.0.0
   xml: ^7.0.1
   local_hero: ^0.3.0
 

--- a/rust/src/api/win32_api.rs
+++ b/rust/src/api/win32_api.rs
@@ -545,19 +545,90 @@ pub fn get_process_list_by_name(process_name: &str) -> anyhow::Result<Vec<Proces
     Ok(Vec::new())
 }
 
-/// Kill processes by name
+#[cfg(target_os = "windows")]
+struct CloseWindowContext {
+    pid: u32,
+    requests_sent: u32,
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn close_process_window(
+    hwnd: windows::Win32::Foundation::HWND,
+    lparam: windows::Win32::Foundation::LPARAM,
+) -> windows::core::BOOL {
+    use windows::core::BOOL;
+    use windows::Win32::Foundation::{LPARAM, WPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetWindowThreadProcessId, PostMessageW, WM_CLOSE,
+    };
+
+    let context = &mut *(lparam.0 as *mut CloseWindowContext);
+    let mut window_pid = 0u32;
+    GetWindowThreadProcessId(hwnd, Some(&mut window_pid));
+    if window_pid == context.pid && PostMessageW(Some(hwnd), WM_CLOSE, WPARAM(0), LPARAM(0)).is_ok()
+    {
+        context.requests_sent += 1;
+    }
+    BOOL(1)
+}
+
+#[cfg(target_os = "windows")]
+fn request_process_close(pid: u32) -> anyhow::Result<u32> {
+    use windows::Win32::Foundation::LPARAM;
+    use windows::Win32::UI::WindowsAndMessaging::EnumWindows;
+
+    let mut context = CloseWindowContext {
+        pid,
+        requests_sent: 0,
+    };
+    unsafe {
+        EnumWindows(
+            Some(close_process_window),
+            LPARAM((&mut context as *mut CloseWindowContext) as isize),
+        )?;
+    }
+    Ok(context.requests_sent)
+}
+
+fn process_name_matches(process_name: &str, executable_name: &str) -> bool {
+    let requested = process_name.strip_suffix(".exe").unwrap_or(process_name);
+    let executable = executable_name
+        .strip_suffix(".exe")
+        .unwrap_or(executable_name);
+    requested.eq_ignore_ascii_case(executable)
+}
+
+/// Ask matching GUI processes to exit normally, then force-terminate only
+/// processes that do not exit before the grace period expires.
 #[cfg(target_os = "windows")]
 pub fn kill_process_by_name(process_name: &str) -> anyhow::Result<u32> {
-    use windows::Win32::Foundation::CloseHandle;
-    use windows::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+    use windows::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
+    use windows::Win32::System::Threading::{
+        OpenProcess, TerminateProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
+    };
+
+    const GRACEFUL_EXIT_TIMEOUT_MS: u32 = 15_000;
 
     let processes = get_process_list_by_name(process_name)?;
     let mut killed_count = 0u32;
 
-    for process in processes {
+    for process in processes
+        .into_iter()
+        .filter(|process| process_name_matches(process_name, &process.name))
+    {
         unsafe {
-            if let Ok(h_process) = OpenProcess(PROCESS_TERMINATE, false, process.pid) {
+            if let Ok(h_process) =
+                OpenProcess(PROCESS_TERMINATE | PROCESS_SYNCHRONIZE, false, process.pid)
+            {
                 if !h_process.is_invalid() {
+                    let close_requested = request_process_close(process.pid).unwrap_or(0) > 0;
+                    if close_requested
+                        && WaitForSingleObject(h_process, GRACEFUL_EXIT_TIMEOUT_MS) == WAIT_OBJECT_0
+                    {
+                        killed_count += 1;
+                        let _ = CloseHandle(h_process);
+                        continue;
+                    }
                     if TerminateProcess(h_process, 0).is_ok() {
                         killed_count += 1;
                     }
@@ -574,6 +645,21 @@ pub fn kill_process_by_name(process_name: &str) -> anyhow::Result<u32> {
 pub fn kill_process_by_name(process_name: &str) -> anyhow::Result<u32> {
     println!("kill_process_by_name (unix): {}", process_name);
     Ok(0)
+}
+
+#[cfg(test)]
+mod process_name_tests {
+    use super::process_name_matches;
+
+    #[test]
+    fn process_name_match_is_exact_and_ignores_exe_suffix() {
+        assert!(process_name_matches("StarCitizen", "StarCitizen.exe"));
+        assert!(process_name_matches("starcitizen.exe", "StarCitizen.exe"));
+        assert!(!process_name_matches(
+            "StarCitizen",
+            "StarCitizen_Launcher.exe"
+        ));
+    }
 }
 
 /// Get disk physical sector size for performance

--- a/test/eac_registrar_test.dart
+++ b/test/eac_registrar_test.dart
@@ -74,7 +74,25 @@ void main() {
     );
   });
 
-  test('deletes the complete EAC distribution before patching', () async {
+  test('wraps an incomplete EAC distribution in EACError', () async {
+    final gameDirectory = p.windows.join(sandbox.path, 'StarCitizen', 'LIVE');
+    await Directory(
+      getAntiCheatDirectory(gameDirectory),
+    ).create(recursive: true);
+
+    expect(
+      () => EacRegistrar().register(gameDirectory: gameDirectory),
+      throwsA(
+        isA<EACError>().having(
+          (error) => error.cause,
+          'cause',
+          isA<FileSystemException>(),
+        ),
+      ),
+    );
+  });
+
+  test('restores the previous EAC distribution when patching fails', () async {
     final eacDirectory = Directory(getAntiCheatDirectory(sandbox.path));
     await eacDirectory.create(recursive: true);
     await File(
@@ -82,11 +100,56 @@ void main() {
     ).writeAsString('old');
     final logs = <String>[];
 
-    await deleteAntiCheatDistribution(sandbox.path, log: logs.add);
-
+    final guard = await EacDistributionPatchGuard.prepare(
+      sandbox.path,
+      log: logs.add,
+    );
     expect(await eacDirectory.exists(), isFalse);
-    expect(logs, ['EAC DIRECTORY SUCCESSFULLY DELETED']);
+    await eacDirectory.create();
+    await File(
+      p.windows.join(eacDirectory.path, 'partial.bin'),
+    ).writeAsString('partial');
+    await guard.rollback();
+
+    expect(
+      await File(p.windows.join(eacDirectory.path, 'old.bin')).exists(),
+      isTrue,
+    );
+    expect(
+      await File(p.windows.join(eacDirectory.path, 'partial.bin')).exists(),
+      isFalse,
+    );
+    expect(logs, contains('EAC DIRECTORY SUCCESSFULLY RESTORED'));
   });
+
+  test(
+    'keeps patched EAC and deletes the rollback backup on success',
+    () async {
+      final eacDirectory = Directory(getAntiCheatDirectory(sandbox.path));
+      await eacDirectory.create(recursive: true);
+      await File(
+        p.windows.join(eacDirectory.path, 'old.bin'),
+      ).writeAsString('old');
+      final logs = <String>[];
+
+      final guard = await EacDistributionPatchGuard.prepare(
+        sandbox.path,
+        log: logs.add,
+      );
+      await eacDirectory.create();
+      await File(
+        p.windows.join(eacDirectory.path, 'new.bin'),
+      ).writeAsString('new');
+      await guard.commit();
+
+      expect(
+        await File(p.windows.join(eacDirectory.path, 'new.bin')).exists(),
+        isTrue,
+      );
+      expect(await guard.backupDirectory?.exists(), isFalse);
+      expect(logs, contains('EAC DIRECTORY SUCCESSFULLY DELETED'));
+    },
+  );
 }
 
 class _RecordingInstallerRunner implements EacInstallerRunner {

--- a/test/eac_registrar_test.dart
+++ b/test/eac_registrar_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:starcitizen_doctor/common/eac/eac_registrar.dart';
+
+void main() {
+  late Directory sandbox;
+
+  setUp(() async {
+    sandbox = await Directory.systemTemp.createTemp('eac_registrar_test_');
+  });
+
+  tearDown(() async {
+    if (await sandbox.exists()) await sandbox.delete(recursive: true);
+  });
+
+  test('skips a build without an EAC distribution', () async {
+    final runner = _RecordingInstallerRunner();
+    final logs = <String>[];
+
+    final outcome = await EacRegistrar(
+      installerRunner: runner,
+    ).register(gameDirectory: sandbox.path, log: logs.add);
+
+    expect(outcome, EacRegistrationOutcome.distributionNotFound);
+    expect(runner.calls, isEmpty);
+    expect(logs, ['No Anti-Cheat distribution was found in this build']);
+  });
+
+  test(
+    'reads productid and unconditionally runs the installer',
+    () async {
+      final gameDirectory = p.windows.join(sandbox.path, 'StarCitizen', 'LIVE');
+      final eacDirectory = Directory(getAntiCheatDirectory(gameDirectory));
+      await eacDirectory.create(recursive: true);
+      await File(
+        p.windows.join(eacDirectory.path, 'Settings.json'),
+      ).writeAsString('{"productid":"build-product-id"}');
+      final runner = _RecordingInstallerRunner();
+      final registrar = EacRegistrar(installerRunner: runner);
+
+      await registrar.register(gameDirectory: gameDirectory);
+      await registrar.register(gameDirectory: gameDirectory);
+
+      expect(runner.calls, hasLength(2));
+      expect(runner.calls.first.productId, 'build-product-id');
+      expect(
+        runner.calls.first.setupPath,
+        p.windows.join(eacDirectory.path, 'EasyAntiCheat_EOS_Setup.exe'),
+      );
+    },
+  );
+
+  test('reports a named EACError when setup fails', () async {
+    final gameDirectory = p.windows.join(sandbox.path, 'StarCitizen', 'PTU');
+    final eacDirectory = Directory(getAntiCheatDirectory(gameDirectory));
+    await eacDirectory.create(recursive: true);
+    await File(
+      p.windows.join(eacDirectory.path, 'Settings.json'),
+    ).writeAsString('{"productid":"ptu-product-id"}');
+    final registrar = EacRegistrar(
+      installerRunner: _RecordingInstallerRunner(error: Exception('failed')),
+    );
+
+    expect(
+      () => registrar.register(gameDirectory: gameDirectory),
+      throwsA(
+        isA<EACError>().having(
+          (error) => error.message,
+          'message',
+          'Unable to register game StarCitizen with environment PTU to the EAC service',
+        ),
+      ),
+    );
+  });
+
+  test('deletes the complete EAC distribution before patching', () async {
+    final eacDirectory = Directory(getAntiCheatDirectory(sandbox.path));
+    await eacDirectory.create(recursive: true);
+    await File(
+      p.windows.join(eacDirectory.path, 'old.bin'),
+    ).writeAsString('old');
+    final logs = <String>[];
+
+    await deleteAntiCheatDistribution(sandbox.path, log: logs.add);
+
+    expect(await eacDirectory.exists(), isFalse);
+    expect(logs, ['EAC DIRECTORY SUCCESSFULLY DELETED']);
+  });
+}
+
+class _RecordingInstallerRunner implements EacInstallerRunner {
+  _RecordingInstallerRunner({this.error});
+
+  final Object? error;
+  final List<({String setupPath, String productId})> calls = [];
+
+  @override
+  Future<void> install({
+    required String setupPath,
+    required String productId,
+  }) async {
+    calls.add((setupPath: setupPath, productId: productId));
+    if (error case final error?) throw error;
+  }
+}

--- a/test/eac_registrar_test.dart
+++ b/test/eac_registrar_test.dart
@@ -28,29 +28,26 @@ void main() {
     expect(logs, ['No Anti-Cheat distribution was found in this build']);
   });
 
-  test(
-    'reads productid and unconditionally runs the installer',
-    () async {
-      final gameDirectory = p.windows.join(sandbox.path, 'StarCitizen', 'LIVE');
-      final eacDirectory = Directory(getAntiCheatDirectory(gameDirectory));
-      await eacDirectory.create(recursive: true);
-      await File(
-        p.windows.join(eacDirectory.path, 'Settings.json'),
-      ).writeAsString('{"productid":"build-product-id"}');
-      final runner = _RecordingInstallerRunner();
-      final registrar = EacRegistrar(installerRunner: runner);
+  test('reads productid and unconditionally runs the installer', () async {
+    final gameDirectory = p.windows.join(sandbox.path, 'StarCitizen', 'LIVE');
+    final eacDirectory = Directory(getAntiCheatDirectory(gameDirectory));
+    await eacDirectory.create(recursive: true);
+    await File(
+      p.windows.join(eacDirectory.path, 'Settings.json'),
+    ).writeAsString('{"productid":"build-product-id"}');
+    final runner = _RecordingInstallerRunner();
+    final registrar = EacRegistrar(installerRunner: runner);
 
-      await registrar.register(gameDirectory: gameDirectory);
-      await registrar.register(gameDirectory: gameDirectory);
+    await registrar.register(gameDirectory: gameDirectory);
+    await registrar.register(gameDirectory: gameDirectory);
 
-      expect(runner.calls, hasLength(2));
-      expect(runner.calls.first.productId, 'build-product-id');
-      expect(
-        runner.calls.first.setupPath,
-        p.windows.join(eacDirectory.path, 'EasyAntiCheat_EOS_Setup.exe'),
-      );
-    },
-  );
+    expect(runner.calls, hasLength(2));
+    expect(runner.calls.first.productId, 'build-product-id');
+    expect(
+      runner.calls.first.setupPath,
+      p.windows.join(eacDirectory.path, 'EasyAntiCheat_EOS_Setup.exe'),
+    );
+  });
 
   test('reports a named EACError when setup fails', () async {
     final gameDirectory = p.windows.join(sandbox.path, 'StarCitizen', 'PTU');
@@ -66,11 +63,13 @@ void main() {
     expect(
       () => registrar.register(gameDirectory: gameDirectory),
       throwsA(
-        isA<EACError>().having(
-          (error) => error.message,
-          'message',
-          'Unable to register game StarCitizen with environment PTU to the EAC service',
-        ),
+        isA<EACError>()
+            .having(
+              (error) => error.message,
+              'message',
+              'Unable to register game StarCitizen with environment PTU to the EAC service',
+            )
+            .having((error) => error.cause, 'cause', isA<Exception>()),
       ),
     );
   });

--- a/test/rsi_launcher_store_test.dart
+++ b/test/rsi_launcher_store_test.dart
@@ -119,6 +119,40 @@ void main() {
     expect(channel['libraryFolder'], r'P:\Games\RSI\');
   });
 
+  test('normalizes a semantic version when versionLabel is empty', () {
+    final store = _storeWithInstalled([
+      {
+        'id': 'SC',
+        'name': 'Star Citizen',
+        'channels': [
+          {
+            'id': 'LIVE',
+            'name': 'Live Release',
+            'version': '4.9.0-live.12248363',
+            'versionLabel': '',
+            'platformId': 'prod',
+            'servicesEndpoint': 'https://live.example',
+            'network': null,
+            'installDir': 'StarCitizen',
+            'status': 'installed',
+            'libraryFolder': r'P:\Games\RSI\',
+          },
+        ],
+      },
+    ]);
+
+    updateRsiLauncherInstalledChannel(
+      store,
+      gameDirectory: r'P:\Games\RSI\StarCitizen\LIVE',
+      releaseInfo: const {},
+      libraryData: const {},
+    );
+
+    final channel = _firstChannel(store);
+    expect(channel['version'], 12248363);
+    expect(channel['versionLabel'], '4.9.0-live.12248363');
+  });
+
   test(
     'backs up and rewrites the encrypted store after validating Data.p4k',
     () async {

--- a/test/rsi_launcher_store_test.dart
+++ b/test/rsi_launcher_store_test.dart
@@ -1,0 +1,212 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:starcitizen_doctor/common/rsi_launcher/launcher_store.dart';
+
+void main() {
+  const nodePayload =
+      '//79gMDB4iihADphYmNkZTrg0ihWJ+U9fDUdiFMRr48y9fP5F1MjcOcpOV8xgiN0WPttIbz/QUGml5Dcd5mkciQ=';
+  final nodeStore = <String, dynamic>{
+    'library': <String, dynamic>{'installed': <dynamic>[]},
+  };
+
+  test('decrypts and reproduces a Node crypto compatibility vector', () {
+    final iv = [
+      255,
+      254,
+      253,
+      128,
+      192,
+      193,
+      226,
+      40,
+      161,
+      0,
+      58,
+      97,
+      98,
+      99,
+      100,
+      101,
+    ];
+    final codec = RsiLauncherStoreCodec(random: _SequenceRandom(iv));
+
+    expect(codec.decrypt(base64Decode(nodePayload)), nodeStore);
+    expect(base64Encode(codec.encrypt(nodeStore)), nodePayload);
+  });
+
+  test('updates an existing channel with schema-safe values and paths', () {
+    final store = _storeWithInstalled([]);
+    (store['library'] as Map)['installed'] = [
+      {
+        'id': 'SC',
+        'name': 'Star Citizen',
+        'channels': [
+          {
+            'id': 'LIVE',
+            'name': 'Live Release',
+            'version': 1,
+            'versionLabel': 'old',
+            'platformId': 'prod',
+            'servicesEndpoint': 'https://old.example',
+            'network': null,
+            'installDir': 'Old',
+            'status': 'installed',
+            'libraryFolder': r'E:\Old\',
+          },
+        ],
+      },
+    ];
+
+    final changed = updateRsiLauncherInstalledChannel(
+      store,
+      gameDirectory: r'P:\Games\RSI\StarCitizen\LIVE',
+      releaseInfo: {
+        'versionLabel': '4.9.0-live.12248363',
+        'servicesEndpoint': 'https://live.example',
+      },
+      libraryData: const {},
+    );
+
+    final channel = _firstChannel(store);
+    expect(changed, isTrue);
+    expect(channel['version'], 12248363);
+    expect(channel['versionLabel'], '4.9.0-live.12248363');
+    expect(channel['servicesEndpoint'], 'https://live.example');
+    expect(channel['status'], 'installed');
+    expect(channel['installDir'], 'StarCitizen');
+    expect(channel['libraryFolder'], r'P:\Games\RSI\');
+  });
+
+  test('adds a missing installed game from RSI library metadata', () {
+    final store = _storeWithInstalled([]);
+    final changed = updateRsiLauncherInstalledChannel(
+      store,
+      gameDirectory: r'P:\Games\RSI\StarCitizen\PTU',
+      releaseInfo: const {'versionLabel': '4.9.0-ptu.12345678'},
+      libraryData: {
+        'games': [
+          {
+            'id': 'SC',
+            'name': 'Star Citizen',
+            'channels': [
+              {
+                'id': 'PTU',
+                'name': 'Public Test Universe',
+                'version': 12345678,
+                'versionLabel': '4.9.0-ptu.12345678',
+                'platformId': 'ptu',
+                'servicesEndpoint': 'https://ptu.example',
+                'network': null,
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    final installed = (store['library'] as Map)['installed'] as List;
+    final channel = _firstChannel(store);
+    expect(changed, isTrue);
+    expect(installed, hasLength(1));
+    expect((installed.first as Map)['id'], 'SC');
+    expect(channel['id'], 'PTU');
+    expect(channel['version'], isA<num>());
+    expect(channel['installDir'], 'StarCitizen');
+    expect(channel['libraryFolder'], r'P:\Games\RSI\');
+  });
+
+  test(
+    'backs up and rewrites the encrypted store after validating Data.p4k',
+    () async {
+      final sandbox = await Directory.systemTemp.createTemp('rsi_store_test_');
+      try {
+        final gameDirectory = p.windows.join(
+          sandbox.path,
+          'StarCitizen',
+          'LIVE',
+        );
+        await Directory(gameDirectory).create(recursive: true);
+        await File(p.windows.join(gameDirectory, 'Data.p4k')).writeAsBytes([1]);
+        final storeFile = File(
+          p.windows.join(sandbox.path, 'launcher store.json'),
+        );
+        final codec = RsiLauncherStoreCodec(random: Random(7));
+        await storeFile.writeAsBytes(
+          codec.encrypt(
+            _storeWithInstalled([
+              {
+                'id': 'SC',
+                'name': 'Star Citizen',
+                'channels': [
+                  {
+                    'id': 'LIVE',
+                    'name': 'Live Release',
+                    'version': 1,
+                    'versionLabel': 'old',
+                    'platformId': 'prod',
+                    'servicesEndpoint': 'https://old.example',
+                    'network': null,
+                    'installDir': 'StarCitizen',
+                    'status': 'installed',
+                    'libraryFolder': '${sandbox.path}\\',
+                  },
+                ],
+              },
+            ]),
+          ),
+        );
+
+        final result = await RsiLauncherStoreService(codec: codec)
+            .syncInstalledChannel(
+              storeFile: storeFile,
+              gameDirectory: gameDirectory,
+              releaseInfo: const {
+                'versionLabel': '4.9.0-live.12248363',
+                'servicesEndpoint': 'https://live.example',
+              },
+              libraryData: const {},
+            );
+
+        expect(result.changed, isTrue);
+        expect(await File(result.backupPath!).exists(), isTrue);
+        expect(
+          _firstChannel(
+            codec.decrypt(await storeFile.readAsBytes()),
+          )['version'],
+          12248363,
+        );
+      } finally {
+        await sandbox.delete(recursive: true);
+      }
+    },
+  );
+}
+
+Map<String, dynamic> _storeWithInstalled(List<dynamic> installed) => {
+  'library': {'installed': installed},
+};
+
+Map _firstChannel(Map store) {
+  final installed = (store['library'] as Map)['installed'] as List;
+  return ((installed.first as Map)['channels'] as List).first as Map;
+}
+
+class _SequenceRandom implements Random {
+  _SequenceRandom(this.values);
+
+  final List<int> values;
+  var _index = 0;
+
+  @override
+  bool nextBool() => nextInt(2) == 1;
+
+  @override
+  double nextDouble() => nextInt(1 << 26) / (1 << 26);
+
+  @override
+  int nextInt(int max) => values[_index++] % max;
+}


### PR DESCRIPTION
## Summary by Sourcery

Refactor Easy Anti-Cheat handling and add support for synchronizing Star Citizen installations with the encrypted RSI Launcher store.

New Features:
- Support decrypting, updating, and re-encrypting the RSI Launcher encrypted launcher store.json to reflect the current game installation.
- Introduce a reusable Easy Anti-Cheat registrar abstraction for registering and removing per-build EAC distributions based on game directory metadata.

Bug Fixes:
- Ensure build_manifest metadata uses the correct install environment name and consistent build number values instead of relying on defaults or partially parsed values.
- Prevent RSI Launcher store synchronization when the launcher is running or when official release metadata is missing, avoiding corrupt or inconsistent state.

Enhancements:
- Simplify EAC registration flows in the P4K updater and Game Doctor to use a shared registrar with clearer user feedback and structured error handling.
- Restrict RSI launcher store discovery to the primary APPDATA path and provide clearer post-install log messages about synchronization outcomes and backups.
- Delete stale Easy Anti-Cheat distributions when loose files are updated to keep installations clean.

Tests:
- Add unit tests covering EAC registration behavior, including missing distributions, product ID handling, error propagation, and distribution deletion.
- Add unit tests for RSI launcher store decryption/encryption compatibility, channel update logic, and on-disk synchronization with backup handling.