### PR TITLE
fix: recognize RSI Launcher index bundles

### DIFF
--- a/lib/common/utils/rsi_launcher_bundle.dart
+++ b/lib/common/utils/rsi_launcher_bundle.dart
@@ -1,0 +1,6 @@
+String? extractRsiLauncherBundleHash(String bundlePath) {
+  final normalizedPath = bundlePath.replaceAll(r'\', '/').replaceFirst(RegExp(r'^/+'), '');
+  return RegExp(
+    r'^(?:app/launcher/static/js/(?:main|index)|app/static/js/main)\.([a-f0-9]+)\.js$',
+  ).firstMatch(normalizedPath)?.group(1);
+}

--- a/lib/ui/tools/dialogs/rsi_launcher_enhance_dialog_ui.dart
+++ b/lib/ui/tools/dialogs/rsi_launcher_enhance_dialog_ui.dart
@@ -15,6 +15,7 @@ import 'package:starcitizen_doctor/common/helper/system_helper.dart';
 import 'package:starcitizen_doctor/common/io/rs_http.dart';
 import 'package:starcitizen_doctor/common/rust/api/asar_api.dart' as asar_api;
 import 'package:starcitizen_doctor/common/utils/log.dart';
+import 'package:starcitizen_doctor/common/utils/rsi_launcher_bundle.dart';
 import 'package:starcitizen_doctor/generated/no_l10n_strings.dart';
 import 'package:starcitizen_doctor/widgets/widgets.dart';
 
@@ -310,20 +311,20 @@ class RsiLauncherEnhanceDialogUI extends HookConsumerWidget {
     try {
       final data = await asar_api.getRsiLauncherAsarData(asarPath: dataPath);
       dPrint("[RsiLauncherEnhanceDialogUI] rsiLauncherPath main.js path == ${data.mainJsPath}");
-      final version = RegExp(r"main\.(\w+)\.js").firstMatch(data.mainJsPath)?.group(1);
-      if (version == null) {
+      final bundleHash = extractRsiLauncherBundleHash(data.mainJsPath);
+      if (bundleHash == null) {
         if (!context.mounted) return null;
         showToast(context, S.current.tools_rsi_launcher_enhance_msg_error_get_launcher_info_error);
         return null;
       }
-      dPrint("[RsiLauncherEnhanceDialogUI] rsiLauncherPath main.js version == $version");
+      dPrint("[RsiLauncherEnhanceDialogUI] rsiLauncherPath bundle hash == $bundleHash");
 
       final mainJsString = String.fromCharCodes(data.mainJsContent);
 
       final (enabledLocalization, enableDownloaderBoost) = _readScriptState(mainJsString);
 
       return RSILauncherStateData(
-        version: version,
+        version: bundleHash,
         data: data,
         serverData: "",
         isPatchInstalled: mainJsString.contains("SC_TOOLBOX"),

--- a/rust/src/api/asar_api.rs
+++ b/rust/src/api/asar_api.rs
@@ -4,9 +4,33 @@ use asar::{AsarReader, AsarWriter};
 use tokio::fs;
 use walkdir::WalkDir;
 
-const RSI_LAUNCHER_MAIN_JS_PREFIXES: [&str; 2] =
-    ["app/launcher/static/js/main.", "app/static/js/main."];
+const RSI_LAUNCHER_MAIN_JS_PREFIXES: [&str; 3] = [
+    "app/launcher/static/js/index.",
+    "app/launcher/static/js/main.",
+    "app/static/js/main.",
+];
 const RSI_LAUNCHER_MAIN_JS_SUFFIX: &str = ".js";
+
+fn rsi_launcher_main_js_priority(path: &str) -> Option<usize> {
+    let normalized_path = path.replace('\\', "/");
+    RSI_LAUNCHER_MAIN_JS_PREFIXES.iter().position(|prefix| {
+        normalized_path.starts_with(prefix)
+            && normalized_path.ends_with(RSI_LAUNCHER_MAIN_JS_SUFFIX)
+    })
+}
+
+fn select_rsi_launcher_main_js_path(paths: &[String]) -> Option<&str> {
+    paths
+        .iter()
+        .filter_map(|path| {
+            rsi_launcher_main_js_priority(path).map(|priority| {
+                let normalized_path = path.replace('\\', "/");
+                (path.as_str(), priority, normalized_path)
+            })
+        })
+        .min_by(|left, right| left.1.cmp(&right.1).then_with(|| left.2.cmp(&right.2)))
+        .map(|(path, _, _)| path)
+}
 
 pub struct RsiLauncherAsarData {
     pub asar_path: String,
@@ -71,24 +95,71 @@ impl RsiLauncherAsarData {
 pub async fn get_rsi_launcher_asar_data(asar_path: &str) -> anyhow::Result<RsiLauncherAsarData> {
     let asar_mem_file = fs::read(asar_path).await?;
     let asar = AsarReader::new(&asar_mem_file, None)?;
-    let mut main_js_path = String::from("");
-    let mut main_js_content: Vec<u8> = Vec::new();
-    asar.files().iter().for_each(|v| {
-        let (path, file) = v;
-        let path_string = path.clone().into_os_string().into_string().unwrap();
-        let normalized_path = path_string.replace('\\', "/");
-        if RSI_LAUNCHER_MAIN_JS_PREFIXES
-            .iter()
-            .any(|prefix| normalized_path.starts_with(prefix))
-            && normalized_path.ends_with(RSI_LAUNCHER_MAIN_JS_SUFFIX)
-        {
-            main_js_path = path_string;
-            main_js_content = file.data().to_vec();
-        }
-    });
+    let paths = asar
+        .files()
+        .keys()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    let main_js_path = select_rsi_launcher_main_js_path(&paths)
+        .unwrap_or_default()
+        .to_string();
+    let main_js_content = asar
+        .files()
+        .iter()
+        .find(|(path, _)| path.to_string_lossy() == main_js_path)
+        .map(|(_, file)| file.data().to_vec())
+        .unwrap_or_default();
     Ok(RsiLauncherAsarData {
         asar_path: asar_path.to_string(),
         main_js_path,
         main_js_content,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_rsi_launcher_main_js_path;
+
+    #[test]
+    fn selects_launcher_index_before_legacy_main_bundles() {
+        let paths = vec![
+            "app/overlay/static/js/index.1e614767.js".to_string(),
+            "app/launcher/static/js/main.f3ea829e.js".to_string(),
+            "app/launcher/static/js/index.deadbeef.js".to_string(),
+            "app/loader/static/js/index.65760705.js".to_string(),
+            "app/static/js/main.legacy123.js".to_string(),
+        ];
+
+        assert_eq!(
+            select_rsi_launcher_main_js_path(&paths),
+            Some("app/launcher/static/js/index.deadbeef.js")
+        );
+    }
+
+    #[test]
+    fn preserves_both_historical_main_layouts() {
+        let launcher_main = vec!["app/launcher/static/js/main.f3ea829e.js".to_string()];
+        let legacy_main = vec!["app/static/js/main.legacy123.js".to_string()];
+
+        assert_eq!(
+            select_rsi_launcher_main_js_path(&launcher_main),
+            Some("app/launcher/static/js/main.f3ea829e.js")
+        );
+        assert_eq!(
+            select_rsi_launcher_main_js_path(&legacy_main),
+            Some("app/static/js/main.legacy123.js")
+        );
+    }
+
+    #[test]
+    fn rejects_unrelated_index_bundles() {
+        let paths = vec![
+            "app/guide-system/static/js/index.ad6b74a0.js".to_string(),
+            "app/loader/static/js/index.65760705.js".to_string(),
+            "app/overlay/static/js/index.1e614767.js".to_string(),
+            "lib/main.js".to_string(),
+        ];
+
+        assert_eq!(select_rsi_launcher_main_js_path(&paths), None);
+    }
 }

--- a/test/rsi_launcher_bundle_test.dart
+++ b/test/rsi_launcher_bundle_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:starcitizen_doctor/common/utils/rsi_launcher_bundle.dart';
+
+void main() {
+  test('extracts hashes from current index and historical main bundles', () {
+    expect(extractRsiLauncherBundleHash(r'app\launcher\static\js\index.deadbeef.js'), 'deadbeef');
+    expect(extractRsiLauncherBundleHash('app/launcher/static/js/main.f3ea829e.js'), 'f3ea829e');
+    expect(extractRsiLauncherBundleHash('app/static/js/main.abcdef12.js'), 'abcdef12');
+  });
+
+  test('rejects unrelated bundles and non-hex hashes', () {
+    expect(extractRsiLauncherBundleHash('app/overlay/static/js/index.1e614767.js'), isNull);
+    expect(extractRsiLauncherBundleHash('lib/main.js'), isNull);
+    expect(extractRsiLauncherBundleHash('app/launcher/static/js/index.not-a-hash.js'), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

- recognize the current `app/launcher/static/js/index.<hash>.js` layout in the Rust ASAR patch path
- retain deterministic fallbacks for both historical `main` bundle layouts
- use the same restricted bundle-name rules in the Dart UI when extracting the dynamic launcher hash
- add synthetic, no-network regression tests; no launcher artifact or hash download is performed by the test suite

## Validation

- `cargo test api::asar_api --lib` (3 passed, 0 ignored)
- `cargo fmt --check`
- `cargo clippy --lib -- -D warnings`
- `flutter test test/rsi_launcher_bundle_test.dart` (2 passed)

Closes #354

## Summary by Sourcery

Recognize current RSI Launcher index bundle layout while preserving compatibility with historical main bundle structures and aligning hash extraction across Rust and Dart.

Bug Fixes:
- Fix RSI Launcher ASAR parsing to correctly detect the current index.<hash>.js bundle layout instead of only legacy main.<hash>.js bundles.

Enhancements:
- Add deterministic selection logic for launcher main bundle paths across multiple historical layouts.
- Introduce a shared RSI launcher bundle hash extractor utility used by the Dart UI to enforce consistent bundle-name rules.

Tests:
- Add Rust unit tests and Flutter tests to validate bundle selection and hash extraction without relying on downloaded launcher artifacts.