### PR TITLE
feat: add P4K assembly download telemetry

### DIFF
--- a/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
+++ b/lib/ui/home/dialogs/home_p4k_update_dialog_ui.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:starcitizen_doctor/api/analytics.dart';
 import 'package:starcitizen_doctor/common/eac/eac_registrar.dart';
 import 'package:starcitizen_doctor/common/helper/launcher_permission_helper.dart';
 import 'package:starcitizen_doctor/common/helper/system_helper.dart';
@@ -12,6 +13,24 @@ import 'package:starcitizen_doctor/widgets/widgets.dart';
 import 'package:window_manager/window_manager.dart';
 
 enum P4kUpdateDialogResult { updated, switchToOfficial }
+
+enum P4kAssemblyTelemetryEvent { clicked, cancelled, failed, succeeded }
+
+String p4kAssemblyTelemetryKey(
+  P4kDownloadSource source,
+  P4kAssemblyTelemetryEvent event,
+) {
+  final sourceKey = source == P4kDownloadSource.official
+      ? 'official'
+      : 'community_mirror';
+  final eventKey = switch (event) {
+    P4kAssemblyTelemetryEvent.clicked => 'clicked',
+    P4kAssemblyTelemetryEvent.cancelled => 'cancelled',
+    P4kAssemblyTelemetryEvent.failed => 'failed',
+    P4kAssemblyTelemetryEvent.succeeded => 'succeeded',
+  };
+  return 'p4k_assemble_download_${sourceKey}_$eventKey';
+}
 
 Future<P4kUpdateDialogResult?> resolveP4kMirrorProviderFailure({
   required P4kMirrorUnavailable error,
@@ -127,6 +146,7 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
   String? _lastProgressEventPhase;
   int _lastProgressLogMillis = 0;
   String _lastProgressLogSignature = "";
+  bool _cancelTelemetryReported = false;
 
   static const _threadOptions = [4, 8, 16, 32, 64, 96];
   static const _maxLogLines = 300;
@@ -465,6 +485,7 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
     required bool deepRepair,
   }) async {
     p4KUpgraderSetDownloadThreads(threads: BigInt.from(_downloadThreads));
+    _reportTelemetry(P4kAssemblyTelemetryEvent.clicked);
     var streamCompletedSuccessfully = false;
     await _runTask(
       status: status,
@@ -635,6 +656,7 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
                 eacPatchGuard = null;
               },
             );
+            _reportTelemetry(P4kAssemblyTelemetryEvent.succeeded);
           }
         } finally {
           await eacPatchGuard?.rollback();
@@ -649,6 +671,7 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
       },
       success: success,
       context: context,
+      reportDownloadFailure: true,
     );
   }
 
@@ -665,6 +688,10 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
 
   void _stopUpdate() {
     if (_cancelling) return;
+    if (!_cancelTelemetryReported) {
+      _cancelTelemetryReported = true;
+      _reportTelemetry(P4kAssemblyTelemetryEvent.cancelled);
+    }
     p4KUpgraderCancel();
     if (!mounted) return;
     setState(() {
@@ -707,10 +734,12 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
     required BuildContext context,
     bool? deepRepair,
     bool Function()? shouldCloseOnSuccess,
+    bool reportDownloadFailure = false,
   }) async {
     setState(() {
       _working = true;
       _cancelling = false;
+      _cancelTelemetryReported = false;
       _lastRunFailed = false;
       _status = status;
       _overallProgressPercent = null;
@@ -741,6 +770,9 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
         if (_status != S.current.p4k_update_canceled) _status = success;
       });
     } catch (e) {
+      if (reportDownloadFailure && !_cancelling) {
+        _reportTelemetry(P4kAssemblyTelemetryEvent.failed);
+      }
       if (!mounted) return;
       final providerError = widget.source == P4kDownloadSource.communityMirror
           ? mapP4kMirrorOperationalError(e)
@@ -774,6 +806,12 @@ class _HomeP4kUpdateDialogUIState extends State<HomeP4kUpdateDialogUI> {
         });
       }
     }
+  }
+
+  void _reportTelemetry(P4kAssemblyTelemetryEvent event) {
+    unawaited(
+      AnalyticsApi.touch(p4kAssemblyTelemetryKey(widget.source, event)),
+    );
   }
 
   P4kUpgraderConfig? _buildConfig({bool deepVerify = false}) {


### PR DESCRIPTION
增加了对P4K下载更详细的数据遥测

## Summary by Sourcery

Add detailed telemetry for P4K assembly downloads across official and community mirror sources.

New Features:
- Add source-specific telemetry for P4K assembly download clicks, cancellations, failures, and successful completions.

Enhancements:
- Track download failures separately from user-initiated cancellations while avoiding duplicate cancellation events.